### PR TITLE
chore: add sponsor funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: s0up4200
+buy_me_a_coffee: s0up4200
+ko_fi: s0up4200


### PR DESCRIPTION
Adds FUNDING.yml with sponsor links for github, buy_me_a_coffee, and ko_fi.