### PR TITLE
Update release link in README for sideloading instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Right-click any magnet or torrent link, pick an instance and category, done.
 
 **From stores**: Use the badges above.
 
-**Sideload from releases:** Download the latest zip from [Releases](https://github.com/soup/qui-chrome/releases), then:
+**Sideload from releases:** Download the latest zip from [Releases](https://github.com/s0up4200/qui-extension/releases), then:
 - **Chrome:** `chrome://extensions` → Enable Developer mode → Drag zip or "Load unpacked"
 - **Firefox:** `about:debugging#/runtime/this-firefox` → Load Temporary Add-on → Select zip
 


### PR DESCRIPTION
This PR fixes the "Releases" link that was set to a previous repo, not existing anymore apparently.

~~Hope it's fine if my commit is Unverified, I did it the lazy way from the web.~~