### PR TITLE
fix: harden torrent handling and setup errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+- Torrent files: stop converting fetched `.torrent` payloads to base64 before messaging; transfer raw bytes instead to reduce Firefox lockups on add.
+- Torrent files: show a clear reload message when the content-script receiver is missing on the current tab.
+- Options: keep save success separate from connection success, and show clearer setup errors for network, timeout, and auth failures.
+
 ## 0.3.0 — 2026-01-29
 
 ### Added

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/lib/messaging';
 import { refreshCache, loadCachedData } from '@/lib/cache';
 import { rebuildMenus, parseMenuId } from '@/lib/menus';
+import { getTorrentFetchErrorMessage } from '@/lib/torrent-file';
 import { cachedData, addPaused, skipRecheck } from '@/lib/storage';
 import { isMagnetUrl } from '@/lib/url';
 
@@ -84,10 +85,15 @@ export default defineBackground(() => {
         }
 
         // Content script is auto-injected via manifest on all URLs
-        const response = (await browser.tabs.sendMessage(tabId, {
-          type: 'fetch-torrent',
-          url: info.linkUrl,
-        })) as FetchTorrentResponse;
+        let response: FetchTorrentResponse;
+        try {
+          response = (await browser.tabs.sendMessage(tabId, {
+            type: 'fetch-torrent',
+            url: info.linkUrl,
+          })) as FetchTorrentResponse;
+        } catch (error) {
+          throw new Error(getTorrentFetchErrorMessage(error));
+        }
 
         if (!response.success) {
           throw new Error(response.error);

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -1,5 +1,6 @@
 import { browser } from 'wxt/browser';
 import type { FetchTorrentMessage, FetchTorrentResponse } from '@/lib/messaging';
+import { responseToTorrentFile } from '@/lib/torrent-file';
 
 const TORRENT_LINK_RE = /(^magnet:)|(\.torrent(\?|#|$))/i;
 const TORRENT_MIME_RE = /application\/x-bittorrent|application\/octet-stream/i;
@@ -46,30 +47,12 @@ function isTorrentLink(link: HTMLAnchorElement): boolean {
   return false;
 }
 
-function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () => reject(new Error('Failed to read torrent data'));
-    reader.readAsDataURL(blob);
-  });
-}
-
 async function fetchTorrent(url: string): Promise<FetchTorrentResponse> {
   const response = await fetch(url, {
     headers: { Accept: 'application/x-bittorrent,application/octet-stream,*/*' },
     credentials: 'include',
   });
-
-  if (!response.ok) {
-    return { success: false, error: `HTTP ${response.status}` };
-  }
-
-  const blob = await response.blob();
-  const data = await blobToDataUrl(blob);
-  const contentType = response.headers.get('content-type') || 'application/x-bittorrent';
-
-  return { success: true, data, contentType };
+  return responseToTorrentFile(response);
 }
 
 export default defineContentScript({

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -15,6 +15,7 @@ import {
   basicAuthPassword,
 } from '@/lib/storage';
 import type { Favorite, CacheData } from '@/lib/storage';
+import { formatConnectionError, getSaveConnectionResult } from '@/lib/connection-errors';
 import { urlToOrigin } from '@/lib/permissions';
 import { sendToBackground } from '@/lib/messaging';
 
@@ -252,11 +253,13 @@ export default function App() {
 
     try {
       await refreshAndUpdateCache();
-      setStatus('success');
-      setMessage('Settings saved');
-    } catch {
-      setStatus('success');
-      setMessage('Settings saved (refresh failed — try the Refresh button)');
+      const result = getSaveConnectionResult(null);
+      setStatus(result.status);
+      setMessage(result.message);
+    } catch (err) {
+      const result = getSaveConnectionResult(err);
+      setStatus(result.status);
+      setMessage(result.message);
     }
   }
 
@@ -270,7 +273,7 @@ export default function App() {
       setMessage('Connected! Found qui server.');
     } catch (err) {
       setStatus('error');
-      setMessage(err instanceof Error ? err.message : 'Connection failed');
+      setMessage(formatConnectionError(err));
     }
   }
 
@@ -284,7 +287,7 @@ export default function App() {
       setMessage('Cache refreshed');
     } catch (err) {
       setStatus('error');
-      setMessage(err instanceof Error ? err.message : 'Refresh failed');
+      setMessage(formatConnectionError(err));
     }
   }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,7 @@
 import ky from 'ky';
+import { blobFromTorrentFile } from './torrent-file';
 import { serverUrl, apiKey, basicAuthUsername, basicAuthPassword } from './storage';
+import type { TorrentFileData } from './messaging';
 
 export interface Instance {
   id: string;
@@ -90,22 +92,18 @@ export async function addTorrent(
 }
 
 /**
- * Add a torrent file (as base64 data URL) to an instance.
+ * Add a torrent file (raw bytes + content type) to an instance.
  * Used for .torrent files fetched from private trackers.
  */
 export async function addTorrentFile(
   instanceId: string,
-  fileData: string,
+  fileData: TorrentFileData,
   category: string,
   options?: AddTorrentOptions,
 ): Promise<unknown> {
   const client = await getClient();
   const form = buildTorrentForm(category, options);
-
-  // Convert base64 data URL to blob
-  const response = await fetch(fileData);
-  const blob = await response.blob();
-  form.append('torrent', blob, 'file.torrent');
+  form.append('torrent', blobFromTorrentFile(fileData), 'file.torrent');
 
   return client.post(`api/instances/${instanceId}/torrents`, { body: form }).json();
 }

--- a/lib/connection-errors.ts
+++ b/lib/connection-errors.ts
@@ -1,0 +1,46 @@
+type UiStatus = 'success' | 'error';
+
+function messageFromUnknown(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function formatConnectionError(error: unknown): string {
+  const message = messageFromUnknown(error);
+
+  if (message.includes('401')) {
+    return 'Unauthorized (401). Check the API key and Basic Auth credentials.';
+  }
+
+  if (message.includes('403')) {
+    return 'Forbidden (403). Check API access rules and any proxy restrictions.';
+  }
+
+  if (
+    message.includes('NetworkError when attempting to fetch resource')
+    || message.includes('Failed to fetch')
+  ) {
+    return 'Could not reach qui. Check the server URL, DNS, TLS certificate, or proxy settings.';
+  }
+
+  if (message.toLowerCase().includes('timed out')) {
+    return 'Request timed out. Check that the qui server is reachable and responding.';
+  }
+
+  return message;
+}
+
+export function getSaveConnectionResult(
+  error: unknown | null,
+): { status: UiStatus; message: string } {
+  if (error === null) {
+    return {
+      status: 'success',
+      message: 'Settings saved. Connected to qui.',
+    };
+  }
+
+  return {
+    status: 'error',
+    message: `Settings saved, but connection failed: ${formatConnectionError(error)}`,
+  };
+}

--- a/lib/messaging.ts
+++ b/lib/messaging.ts
@@ -14,6 +14,11 @@ export type FetchTorrentMessage = {
   url: string;
 };
 
+export type TorrentFileData = {
+  bytes: ArrayBuffer;
+  contentType: string;
+};
+
 /** Message sent from content script to toggle action state based on page links */
 export type PageTorrentLinksMessage = {
   type: 'page-torrent-links';
@@ -22,7 +27,7 @@ export type PageTorrentLinksMessage = {
 
 /** Response from content script after fetching torrent */
 export type FetchTorrentResponse =
-  | { success: true; data: string; contentType: string }
+  | { success: true; data: TorrentFileData }
   | { success: false; error: string };
 
 export type ApiResponse<T> =

--- a/lib/torrent-file.ts
+++ b/lib/torrent-file.ts
@@ -1,0 +1,29 @@
+import type { FetchTorrentResponse, TorrentFileData } from './messaging';
+
+const MISSING_RECEIVER_FRAGMENT = 'Receiving end does not exist';
+
+export async function responseToTorrentFile(response: Response): Promise<FetchTorrentResponse> {
+  if (!response.ok) {
+    return { success: false, error: `HTTP ${response.status}` };
+  }
+
+  return {
+    success: true,
+    data: {
+      bytes: await response.arrayBuffer(),
+      contentType: response.headers.get('content-type') || 'application/x-bittorrent',
+    },
+  };
+}
+
+export function blobFromTorrentFile(file: TorrentFileData): Blob {
+  return new Blob([file.bytes], { type: file.contentType });
+}
+
+export function getTorrentFetchErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes(MISSING_RECEIVER_FRAGMENT)) {
+    return 'Reload the page and try again. qui could not reach the torrent helper on this tab.';
+  }
+  return message;
+}

--- a/test/connection-errors.test.ts
+++ b/test/connection-errors.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { formatConnectionError, getSaveConnectionResult } from '../lib/connection-errors';
+
+describe('formatConnectionError', () => {
+  test('maps network errors to actionable setup guidance', () => {
+    expect(
+      formatConnectionError(new Error('NetworkError when attempting to fetch resource.')),
+    ).toBe('Could not reach qui. Check the server URL, DNS, TLS certificate, or proxy settings.');
+  });
+
+  test('maps 401 errors to auth guidance', () => {
+    expect(
+      formatConnectionError(
+        new Error('Request failed with status code 401 Unauthorized: GET http://qui/api/instances'),
+      ),
+    ).toBe('Unauthorized (401). Check the API key and Basic Auth credentials.');
+  });
+
+  test('maps 403 errors to access guidance', () => {
+    expect(
+      formatConnectionError(
+        new Error('Request failed with status code 403 Forbidden: GET http://qui/api/instances'),
+      ),
+    ).toBe('Forbidden (403). Check API access rules and any proxy restrictions.');
+  });
+
+  test('maps timeout errors to reachability guidance', () => {
+    expect(formatConnectionError(new Error('Request timed out'))).toBe(
+      'Request timed out. Check that the qui server is reachable and responding.',
+    );
+  });
+});
+
+describe('getSaveConnectionResult', () => {
+  test('returns success copy when refresh succeeds', () => {
+    expect(getSaveConnectionResult(null)).toEqual({
+      status: 'success',
+      message: 'Settings saved. Connected to qui.',
+    });
+  });
+
+  test('keeps save success separate from connection failure', () => {
+    expect(
+      getSaveConnectionResult(new Error('NetworkError when attempting to fetch resource.')),
+    ).toEqual({
+      status: 'error',
+      message:
+        'Settings saved, but connection failed: Could not reach qui. Check the server URL, DNS, TLS certificate, or proxy settings.',
+    });
+  });
+});

--- a/test/torrent-file.test.ts
+++ b/test/torrent-file.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  blobFromTorrentFile,
+  getTorrentFetchErrorMessage,
+  responseToTorrentFile,
+} from '../lib/torrent-file';
+
+describe('responseToTorrentFile', () => {
+  test('returns raw torrent bytes without base64 inflation', async () => {
+    const bytes = Uint8Array.from([0x64, 0x38, 0x3a, 0x61, 0x62, 0x63, 0x64, 0x65]);
+    const response = new Response(bytes, {
+      status: 200,
+      headers: { 'content-type': 'application/x-bittorrent' },
+    });
+
+    const result = await responseToTorrentFile(response);
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error('expected success');
+    }
+    expect(result.data.contentType).toBe('application/x-bittorrent');
+    expect(Array.from(new Uint8Array(result.data.bytes))).toEqual(Array.from(bytes));
+  });
+
+  test('returns HTTP error status for failed fetches', async () => {
+    const response = new Response('forbidden', { status: 403 });
+
+    const result = await responseToTorrentFile(response);
+
+    expect(result).toEqual({ success: false, error: 'HTTP 403' });
+  });
+});
+
+describe('blobFromTorrentFile', () => {
+  test('rebuilds a blob from transferred bytes', async () => {
+    const bytes = Uint8Array.from([1, 2, 3, 4]);
+    const blob = blobFromTorrentFile({
+      bytes: bytes.buffer,
+      contentType: 'application/x-bittorrent',
+    });
+
+    expect(blob.type).toBe('application/x-bittorrent');
+    expect(Array.from(new Uint8Array(await blob.arrayBuffer()))).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('getTorrentFetchErrorMessage', () => {
+  test('maps missing content script receiver to refresh guidance', () => {
+    const message = getTorrentFetchErrorMessage(
+      new Error('Could not establish connection. Receiving end does not exist.'),
+    );
+
+    expect(message).toBe(
+      'Reload the page and try again. qui could not reach the torrent helper on this tab.',
+    );
+  });
+
+  test('passes through other errors unchanged', () => {
+    const message = getTorrentFetchErrorMessage(new Error('NetworkError when attempting to fetch resource.'));
+
+    expect(message).toBe('NetworkError when attempting to fetch resource.');
+  });
+});


### PR DESCRIPTION
This hardens the torrent-file path by transferring raw bytes instead of base64 payloads and by turning missing content-script receivers into a clear reload prompt. That should reduce Firefox lockups and make the stale-tab failure mode understandable.

It also tightens the options flow so saved settings do not imply a successful connection when refresh fails, and surfaces clearer auth, network, and timeout setup errors. Includes regression coverage for both paths.