### PR TITLE
fix: always show (No category) in favorites list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Options: always show `(No category)` in the favorites list so it can be starred even when an instance has categories (#8).
 - Torrent files: stop converting fetched `.torrent` payloads to base64 before messaging; transfer raw bytes instead to reduce Firefox lockups on add.
 - Torrent files: show a clear reload message when the content-script receiver is missing on the current tab.
 - Options: keep save success separate from connection success, and show clearer setup errors for network, timeout, and auth failures.

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -635,9 +635,7 @@ export default function App() {
                   const categories = filteredCategories(instance.id);
                   const allCategories = cachedData.categoriesByInstance[instance.id] || [];
                   const isExpanded = expandedInstances.has(instance.id);
-                  const rows = categories.length > 0
-                    ? categories.map((cat) => ({ category: cat.name }))
-                    : [{ category: '' }];
+                  const rows = [{ category: '' }, ...categories.map((cat) => ({ category: cat.name }))];
 
                   return (
                     <Flex key={instance.id} direction="column">
@@ -655,7 +653,7 @@ export default function App() {
                           {instance.name}
                         </Text>
                         <Badge size="1" variant="soft" color="gray">
-                          {allCategories.length || 1}
+                          {allCategories.length + 1}
                         </Badge>
                       </Flex>
 


### PR DESCRIPTION
The favorites list in options only rendered a `(No category)` row when an instance had zero categories, so it couldn't be starred otherwise. The row is now always the first entry and the instance badge counts it.

Closes #8