### PR TITLE
fix: base64-encode torrent payloads for Chrome message passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Torrent files: transfer fetched `.torrent` payloads as base64 again — Chrome JSON-serializes extension messages, so raw `ArrayBuffer`s arrived as empty objects and every file-based add failed with HTTP 500. The encode is chunked to avoid the Firefox lockups that prompted the raw-bytes change.
 - Torrent files: stop converting fetched `.torrent` payloads to base64 before messaging; transfer raw bytes instead to reduce Firefox lockups on add.
 - Torrent files: show a clear reload message when the content-script receiver is missing on the current tab.
 - Options: keep save success separate from connection success, and show clearer setup errors for network, timeout, and auth failures.

--- a/lib/messaging.ts
+++ b/lib/messaging.ts
@@ -15,7 +15,9 @@ export type FetchTorrentMessage = {
 };
 
 export type TorrentFileData = {
-  bytes: ArrayBuffer;
+  // ponytail: base64, not ArrayBuffer — Chrome JSON-serializes extension
+  // messages, so raw buffers arrive as {} in the background.
+  base64: string;
   contentType: string;
 };
 

--- a/lib/torrent-file.ts
+++ b/lib/torrent-file.ts
@@ -10,14 +10,25 @@ export async function responseToTorrentFile(response: Response): Promise<FetchTo
   return {
     success: true,
     data: {
-      bytes: await response.arrayBuffer(),
+      base64: bytesToBase64(new Uint8Array(await response.arrayBuffer())),
       contentType: response.headers.get('content-type') || 'application/x-bittorrent',
     },
   };
 }
 
+// ponytail: chunked to stay linear and under the fromCharCode arg limit —
+// an unchunked encode is what locks up on large files.
+function bytesToBase64(bytes: Uint8Array): string {
+  const chunks: string[] = [];
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    chunks.push(String.fromCharCode(...bytes.subarray(i, i + 0x8000)));
+  }
+  return btoa(chunks.join(''));
+}
+
 export function blobFromTorrentFile(file: TorrentFileData): Blob {
-  return new Blob([file.bytes], { type: file.contentType });
+  const bytes = Uint8Array.from(atob(file.base64), (c) => c.charCodeAt(0));
+  return new Blob([bytes], { type: file.contentType });
 }
 
 export function getTorrentFetchErrorMessage(error: unknown): string {

--- a/test/torrent-file.test.ts
+++ b/test/torrent-file.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../lib/torrent-file';
 
 describe('responseToTorrentFile', () => {
-  test('returns raw torrent bytes without base64 inflation', async () => {
+  test('encodes bytes as a JSON-safe base64 string that round-trips', async () => {
     const bytes = Uint8Array.from([0x64, 0x38, 0x3a, 0x61, 0x62, 0x63, 0x64, 0x65]);
     const response = new Response(bytes, {
       status: 200,
@@ -20,7 +20,12 @@ describe('responseToTorrentFile', () => {
       throw new Error('expected success');
     }
     expect(result.data.contentType).toBe('application/x-bittorrent');
-    expect(Array.from(new Uint8Array(result.data.bytes))).toEqual(Array.from(bytes));
+    expect(typeof result.data.base64).toBe('string');
+
+    // Chrome JSON-serializes extension messages — payload must survive that.
+    const transferred = JSON.parse(JSON.stringify(result.data));
+    const blob = blobFromTorrentFile(transferred);
+    expect(Array.from(new Uint8Array(await blob.arrayBuffer()))).toEqual(Array.from(bytes));
   });
 
   test('returns HTTP error status for failed fetches', async () => {
@@ -33,10 +38,9 @@ describe('responseToTorrentFile', () => {
 });
 
 describe('blobFromTorrentFile', () => {
-  test('rebuilds a blob from transferred bytes', async () => {
-    const bytes = Uint8Array.from([1, 2, 3, 4]);
+  test('rebuilds a blob from transferred base64', async () => {
     const blob = blobFromTorrentFile({
-      bytes: bytes.buffer,
+      base64: btoa(String.fromCharCode(1, 2, 3, 4)),
       contentType: 'application/x-bittorrent',
     });
 


### PR DESCRIPTION
Since #6, `.torrent` file adds failed with HTTP 500 on Chrome: extension messages are JSON-serialized there, so the raw `ArrayBuffer` from the content script arrived in the background as an empty object and the upload body became the literal string `[object Object]`. Firefox was unaffected (structured clone).

The payload now crosses messaging as base64 again, encoded in 32 KB chunks so the unchunked-encode lockups that motivated the raw-bytes change in #6 don't return. Tests round-trip the payload through `JSON.parse(JSON.stringify(...))` to mirror Chrome's serialization. Confirmed working against a live qui server.