### PR TITLE
feat: send torrents to configured save paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ bun run zip             # Package for Chrome Web Store
 bun run zip:firefox     # Package for Firefox
 ```
 
-No test or lint commands are configured.
+`bun test` runs the unit tests in `test/`. No lint command is configured.
 
 ## Workflow
 
@@ -38,9 +38,10 @@ Built with **WXT** (Vite-based extension framework), **React 19**, **Tailwind CS
 
 - **`api.ts`** — ky-based HTTP client wrapping qui endpoints (`GET /api/instances`, `GET /api/instances/{id}/categories`, `POST /api/instances/{id}/torrents`).
 - **`cache.ts`** — Fetches and caches instances + categories to chrome.storage.local.
-- **`menus.ts`** — Builds nested context menu structure from cached data (favorites appear first).
+- **`menus.ts`** — Builds nested context menu structure from cached data (favorites appear first, save paths last).
+- **`menu-id.ts`** — Encodes and parses context menu item ids. Has no browser imports so `bun test` can load it.
 - **`messaging.ts`** — Typed message passing between background, popup, and options.
-- **`storage.ts`** — Typed chrome.storage.local definitions (serverUrl, apiKey, favorites, cachedData).
+- **`storage.ts`** — Typed chrome.storage.local definitions (serverUrl, apiKey, favorites, savePaths, cachedData).
 - **`permissions.ts`** — URL-to-origin conversion for host permission requests.
 
 ### Data Flow
@@ -48,13 +49,13 @@ Built with **WXT** (Vite-based extension framework), **React 19**, **Tailwind CS
 1. Options page saves server URL + API key to chrome.storage
 2. Background service worker caches instances/categories (refreshed every 15 min via alarm)
 3. Cached data builds nested context menus: top-level per instance, sub-items per category
-4. Menu click → `addTorrent(instanceId, url, category)` → success/error notification
+4. Menu click → `addTorrent(instanceId, url, category, { savePath })` → success/error notification
 
 ### Key Patterns
 
 - **MV3 service worker**: No persistent state; all persistence via chrome.storage.local
 - **Context menus registered in `onInstalled`**: Menus persist across service worker restarts
-- **Menu item ID format**: `add|{instanceId}|{category}` (parsed on click)
+- **Menu item ID format**: `add|{instanceId}|{category}` or `path|{instanceId}|{savePath}` (parsed on click, split on the first two `|` only)
 - **Path alias**: `@/*` maps to project root in imports
 - **CSS**: Tailwind v4 CSS-first config with Radix Themes dark mode via `@layer`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Menu: send a torrent to a configured save path (#13). Set the paths in options, one per line. Each instance submenu lists them after the categories. Path items are hidden in favorites-only mode.
+
 ### Changed
 - Permissions: drop the required `<all_urls>` host permission and the always-on content script (#3). Installation no longer warns about reading data on all websites.
 - Torrent files: fetch `.torrent` links inside the clicked tab with `activeTab` and `scripting`. The context-menu click grants both.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- Menu: send a torrent to a configured save path (#13). Set the paths in options, one per line. Each instance submenu lists them after the categories. Path items are hidden in favorites-only mode.
+- Menu: send a torrent to a configured save path (#13). Set the paths in options, one per line. Each instance submenu lists them after the categories. Path items show in favorites-only mode too.
 - Cross-seed: a **Cross-seed in qui** context-menu item for `.torrent` links (#11). It lists every enabled instance and opens a picker window with the torrents qui ranks by file overlap. Pick a target from the ranked list or search the instance by name for any other torrent, set category and tags, and qui adds the torrent pinned to that target with a full recheck. Needs qui 1.28.0 or newer. Magnet links are rejected because they carry no file list.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Chrome/Firefox extension for adding torrents to qBittorrent instances managed by [qui](https://github.com/autobrr/qui).
 
-Right-click any magnet or torrent link, pick an instance and category, done.
+Right-click any magnet or torrent link, pick an instance and a category or save path, done.
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/kbjnjgihepmcoilegnghgpmijbecoili?label=Chrome)](https://chromewebstore.google.com/detail/kbjnjgihepmcoilegnghgpmijbecoili)
 [![Firefox Add-ons](https://img.shields.io/amo/v/qui?label=Firefox)](https://addons.mozilla.org/en-US/firefox/addon/qui/)

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -191,8 +191,6 @@ export default defineBackground(() => {
     const cache = await loadCachedData();
     const instance = cache.instances.find((i) => String(i.id) === parsed.instanceId);
     const instanceName = instance?.name ?? parsed.instanceId;
-    const { category, savePath } = parsed;
-    const target = savePath ?? category;
 
     if (parsed.action === 'cross-seed') {
       await openCrossSeedPicker(info, tab, parsed.instanceId, instanceName);

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,7 +1,8 @@
 import { getInstances, getCategories, addTorrent, addTorrentFile, type AddTorrentOptions } from '@/lib/api';
 import type { ApiMessage, ApiResponse, FetchTorrentResponse } from '@/lib/messaging';
 import { refreshCache, loadCachedData } from '@/lib/cache';
-import { rebuildMenus, parseMenuId } from '@/lib/menus';
+import { rebuildMenus } from '@/lib/menus';
+import { parseMenuId } from '@/lib/menu-id';
 import { fetchTorrentInPage } from '@/lib/torrent-file';
 import { cachedData, addPaused, skipRecheck } from '@/lib/storage';
 import { isMagnetUrl } from '@/lib/url';
@@ -53,13 +54,15 @@ export default defineBackground(() => {
     const cache = await loadCachedData();
     const instance = cache.instances.find((i) => String(i.id) === parsed.instanceId);
     const instanceName = instance?.name ?? parsed.instanceId;
+    const { category, savePath } = parsed;
+    const target = savePath ?? category;
 
     try {
-      const options = await getTorrentOptions();
+      const options: AddTorrentOptions = { ...(await getTorrentOptions()), savePath };
 
       if (isMagnetUrl(info.linkUrl)) {
         // Magnet links can be sent directly to qui
-        await addTorrent(parsed.instanceId, info.linkUrl, parsed.category, options);
+        await addTorrent(parsed.instanceId, info.linkUrl, category, options);
       } else {
         // .torrent URLs: fetch inside the clicked tab to use the page's
         // cookies/session. The context-menu click grants activeTab.
@@ -84,14 +87,14 @@ export default defineBackground(() => {
           throw new Error(response?.error ?? 'Could not fetch the torrent file from this tab');
         }
 
-        await addTorrentFile(parsed.instanceId, response.data, parsed.category, options);
+        await addTorrentFile(parsed.instanceId, response.data, category, options);
       }
 
       browser.notifications.create(`success-${Date.now()}`, {
         type: 'basic',
         iconUrl: browser.runtime.getURL('/icon-128.png'),
         title: 'Torrent Added',
-        message: `Added to ${instanceName}${parsed.category ? ' / ' + parsed.category : ''}`,
+        message: `Added to ${instanceName}${target ? ' / ' + target : ''}`,
       });
     } catch (err) {
       browser.notifications.create(`error-${Date.now()}`, {
@@ -159,7 +162,12 @@ export default defineBackground(() => {
   browser.storage.onChanged.addListener((changes, areaName) => {
     if (
       areaName === 'local'
-      && (changes['favorites'] || changes['favoritesOnly'] || changes['enabledInstances'])
+      && (
+        changes['favorites']
+        || changes['favoritesOnly']
+        || changes['enabledInstances']
+        || changes['savePaths']
+      )
     ) {
       rebuildMenus();
     }

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Card, Heading, Text, TextField, Button, Flex, Box, IconButton, Switch, Grid, ScrollArea, Badge } from '@radix-ui/themes';
+import { Card, Heading, Text, TextField, TextArea, Button, Flex, Box, IconButton, Switch, Grid, ScrollArea, Badge } from '@radix-ui/themes';
 import { StarFilledIcon, StarIcon, ReloadIcon, CopyIcon, CheckIcon, ExternalLinkIcon, GitHubLogoIcon, ChevronDownIcon, ChevronRightIcon, MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import { Coffee } from 'lucide-react';
 import {
@@ -9,6 +9,7 @@ import {
   addPaused,
   skipRecheck,
   favoritesOnly,
+  savePaths as savePathsStorage,
   enabledInstances as enabledInstancesStorage,
   basicAuthUsername,
   basicAuthPassword,
@@ -79,6 +80,7 @@ export default function App() {
   const [favs, setFavs] = useState<Favorite[]>([]);
   const [paused, setPaused] = useState(false);
   const [skipCheck, setSkipCheck] = useState(false);
+  const [savePathsText, setSavePathsText] = useState('');
   const [enabledInstanceIds, setEnabledInstanceIds] = useState<string[] | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
   const [filter, setFilter] = useState('');
@@ -102,6 +104,7 @@ export default function App() {
         savedFavs,
         savedPaused,
         savedSkip,
+        savedSavePaths,
         savedFavsOnly,
         savedEnabledInstances,
         savedAuthUsername,
@@ -112,6 +115,7 @@ export default function App() {
         favorites.getValue(),
         addPaused.getValue(),
         skipRecheck.getValue(),
+        savePathsStorage.getValue(),
         favoritesOnly.getValue(),
         enabledInstancesStorage.getValue(),
         basicAuthUsername.getValue(),
@@ -123,6 +127,7 @@ export default function App() {
       setFavs(savedFavs);
       setPaused(savedPaused);
       setSkipCheck(savedSkip);
+      setSavePathsText(savedSavePaths.join('\n'));
       setFavsOnly(savedFavsOnly);
       setEnabledInstanceIds(savedEnabledInstances);
       setAuthUsername(savedAuthUsername);
@@ -325,6 +330,20 @@ export default function App() {
     await skipRecheck.setValue(checked);
   }
 
+  // One path per line. Drop blank lines, trim, collapse duplicates.
+  function parseSavePaths(text: string): string[] {
+    return [...new Set(text.split('\n').map((p) => p.trim()).filter(Boolean))];
+  }
+
+  async function handleSavePathsChange(text: string) {
+    setSavePathsText(text);
+    await savePathsStorage.setValue(parseSavePaths(text));
+  }
+
+  function handleSavePathsBlur() {
+    setSavePathsText(parseSavePaths(savePathsText).join('\n'));
+  }
+
   async function handleFavsOnlyChange(checked: boolean) {
     setFavsOnly(checked);
     await favoritesOnly.setValue(checked);
@@ -498,6 +517,25 @@ export default function App() {
                 <Switch checked={skipCheck} onCheckedChange={handleSkipChange} />
               </Flex>
 
+            </Flex>
+          </Card>
+
+          {/* Save paths */}
+          <Card>
+            <Flex direction="column" gap="3">
+              <Heading size="3">Save paths</Heading>
+              <Text size="2" color="gray">
+                One absolute path per line. Each path is added to every instance in the context menu.
+              </Text>
+              <TextArea
+                size="2"
+                rows={4}
+                value={savePathsText}
+                onChange={(e) => handleSavePathsChange(e.target.value)}
+                onBlur={handleSavePathsBlur}
+                placeholder={'/data/downloads/movies\nD:\\Downloads\\Music'}
+                spellCheck={false}
+              />
             </Flex>
           </Card>
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -67,12 +67,17 @@ export async function getCategories(instanceId: string): Promise<Category[]> {
 export interface AddTorrentOptions {
   paused?: boolean;
   skipChecking?: boolean;
+  /** Absolute path on the qBittorrent host. qui disables autoTMM when set. */
+  savePath?: string;
 }
 
 function buildTorrentForm(category: string, options?: AddTorrentOptions): FormData {
   const form = new FormData();
   if (category) {
     form.append('category', category);
+  }
+  if (options?.savePath) {
+    form.append('savepath', options.savePath);
   }
   if (options?.paused) {
     form.append('paused', 'true');

--- a/lib/menu-id.ts
+++ b/lib/menu-id.ts
@@ -1,0 +1,38 @@
+// Pure menu id helpers. Kept free of browser imports so bun:test can load them.
+
+/** `savePath` is set only for `path|` items. */
+export interface MenuTarget {
+  instanceId: string;
+  category: string;
+  savePath?: string;
+}
+
+export function makeMenuId(instanceId: string, category: string): string {
+  return `add|${instanceId}|${category}`;
+}
+
+export function makePathMenuId(instanceId: string, savePath: string): string {
+  return `path|${instanceId}|${savePath}`;
+}
+
+/** Split `{prefix}|{instanceId}|{rest}` on the first two separators only; `rest` may contain `|`. */
+export function parseMenuId(menuItemId: string): MenuTarget | null {
+  if (typeof menuItemId !== 'string') {
+    return null;
+  }
+  const firstSep = menuItemId.indexOf('|');
+  const secondSep = menuItemId.indexOf('|', firstSep + 1);
+  if (firstSep === -1 || secondSep === -1) {
+    return null;
+  }
+  const prefix = menuItemId.slice(0, firstSep);
+  const instanceId = menuItemId.slice(firstSep + 1, secondSep);
+  const rest = menuItemId.slice(secondSep + 1);
+  if (prefix === 'add') {
+    return { instanceId, category: rest };
+  }
+  if (prefix === 'path') {
+    return { instanceId, category: '', savePath: rest };
+  }
+  return null;
+}

--- a/lib/menus.ts
+++ b/lib/menus.ts
@@ -1,26 +1,6 @@
 import { loadCachedData } from '@/lib/cache';
-import { favorites, favoritesOnly, enabledInstances, type Favorite } from '@/lib/storage';
-
-export function makeMenuId(instanceId: string, category: string): string {
-  return `add|${instanceId}|${category}`;
-}
-
-export function parseMenuId(
-  menuItemId: string,
-): { instanceId: string; category: string } | null {
-  if (typeof menuItemId !== 'string' || !menuItemId.startsWith('add|')) {
-    return null;
-  }
-  const firstSep = menuItemId.indexOf('|');
-  const secondSep = menuItemId.indexOf('|', firstSep + 1);
-  if (secondSep === -1) {
-    return null;
-  }
-  return {
-    instanceId: menuItemId.slice(firstSep + 1, secondSep),
-    category: menuItemId.slice(secondSep + 1),
-  };
-}
+import { favorites, favoritesOnly, enabledInstances, savePaths, type Favorite } from '@/lib/storage';
+import { makeMenuId, makePathMenuId } from '@/lib/menu-id';
 
 function isStarred(
   favs: Favorite[],
@@ -36,10 +16,11 @@ export async function rebuildMenus(): Promise<void> {
   await browser.contextMenus.removeAll();
 
   const cache = await loadCachedData();
-  const [favs, onlyFavs, enabled] = await Promise.all([
+  const [favs, onlyFavs, enabled, paths] = await Promise.all([
     favorites.getValue(),
     favoritesOnly.getValue(),
     enabledInstances.getValue(),
+    savePaths.getValue(),
   ]);
 
   if (!cache.instances.length) {
@@ -178,6 +159,24 @@ export async function rebuildMenus(): Promise<void> {
           title: cat.name,
           contexts: ['link'],
         });
+      }
+
+      // Save paths are global and have no category, so favoritesOnly skips them.
+      if (paths.length > 0) {
+        browser.contextMenus.create({
+          id: `paths-sep-${instance.id}`,
+          parentId,
+          type: 'separator',
+          contexts: ['link'],
+        });
+        for (const savePath of paths) {
+          browser.contextMenus.create({
+            id: makePathMenuId(instance.id, savePath),
+            parentId,
+            title: savePath,
+            contexts: ['link'],
+          });
+        }
       }
     }
   }

--- a/lib/menus.ts
+++ b/lib/menus.ts
@@ -88,7 +88,10 @@ function buildSendMenu(
   onlyFavs: boolean,
   paths: string[],
 ): void {
-  if (onlyFavs && favs.length === 0) {
+  // Save paths are global, so they show in every mode.
+  const hasPaths = paths.length > 0;
+
+  if (onlyFavs && favs.length === 0 && !hasPaths) {
     browser.contextMenus.create({
       id: 'qui-no-favorites',
       title: 'No favorites (star items in popup)',
@@ -98,7 +101,7 @@ function buildSendMenu(
     return;
   }
 
-  if (onlyFavs) {
+  if (onlyFavs && !hasPaths) {
     const hasAnyFavorites = selectedInstances.some((instance) => {
       const categories = cache.categoriesByInstance[instance.id] ?? [];
       if (isStarred(favs, instance.id, '')) return true;
@@ -126,96 +129,62 @@ function buildSendMenu(
 
   for (const instance of selectedInstances) {
     const categories = cache.categoriesByInstance[instance.id] ?? [];
+    const starred = categories.filter((c) => isStarred(favs, instance.id, c.name));
+    const unstarred = categories.filter((c) => !isStarred(favs, instance.id, c.name));
+    const hasNoCategoryFav = isStarred(favs, instance.id, '');
 
-    if (onlyFavs) {
-      const starredCategories = categories.filter((c) =>
-        isStarred(favs, instance.id, c.name),
-      );
-      const hasNoCategoryFav = isStarred(favs, instance.id, '');
+    const showNoCategory = !onlyFavs || hasNoCategoryFav;
+    const shownCategories = onlyFavs ? starred : [...starred, ...unstarred];
 
-      if (starredCategories.length === 0 && !hasNoCategoryFav) {
-        continue;
-      }
+    if (!showNoCategory && shownCategories.length === 0 && !hasPaths) {
+      continue;
+    }
 
-      const instanceMenuId = `instance-${instance.id}`;
-      const parentId = singleInstance ? 'send-to-qui' : instanceMenuId;
-      if (!singleInstance) {
-        browser.contextMenus.create({
-          id: instanceMenuId,
-          parentId: 'send-to-qui',
-          title: instance.name,
-          contexts: ['link'],
-        });
-      }
+    const instanceMenuId = `instance-${instance.id}`;
+    const parentId = singleInstance ? 'send-to-qui' : instanceMenuId;
+    if (!singleInstance) {
+      browser.contextMenus.create({
+        id: instanceMenuId,
+        parentId: 'send-to-qui',
+        title: instance.name,
+        contexts: ['link'],
+      });
+    }
 
-      if (hasNoCategoryFav) {
-        browser.contextMenus.create({
-          id: makeMenuId(instance.id, ''),
-          parentId,
-          title: '(No category)',
-          contexts: ['link'],
-        });
-      }
-
-      for (const cat of starredCategories) {
-        browser.contextMenus.create({
-          id: makeMenuId(instance.id, cat.name),
-          parentId,
-          title: cat.name,
-          contexts: ['link'],
-        });
-      }
-    } else {
-      const instanceMenuId = `instance-${instance.id}`;
-      const parentId = singleInstance ? 'send-to-qui' : instanceMenuId;
-      if (!singleInstance) {
-        browser.contextMenus.create({
-          id: instanceMenuId,
-          parentId: 'send-to-qui',
-          title: instance.name,
-          contexts: ['link'],
-        });
-      }
-
+    if (showNoCategory) {
       browser.contextMenus.create({
         id: makeMenuId(instance.id, ''),
         parentId,
         title: '(No category)',
         contexts: ['link'],
       });
+    }
 
-      const starred = categories.filter((c) =>
-        isStarred(favs, instance.id, c.name),
-      );
-      const unstarred = categories.filter(
-        (c) => !isStarred(favs, instance.id, c.name),
-      );
+    for (const cat of shownCategories) {
+      browser.contextMenus.create({
+        id: makeMenuId(instance.id, cat.name),
+        parentId,
+        title: cat.name,
+        contexts: ['link'],
+      });
+    }
 
-      for (const cat of [...starred, ...unstarred]) {
-        browser.contextMenus.create({
-          id: makeMenuId(instance.id, cat.name),
-          parentId,
-          title: cat.name,
-          contexts: ['link'],
-        });
-      }
-
-      // Save paths are global and have no category, so favoritesOnly skips them.
-      if (paths.length > 0) {
+    if (hasPaths) {
+      if (showNoCategory || shownCategories.length > 0) {
         browser.contextMenus.create({
           id: `paths-sep-${instance.id}`,
           parentId,
           type: 'separator',
           contexts: ['link'],
         });
-        for (const savePath of paths) {
-          browser.contextMenus.create({
-            id: makePathMenuId(instance.id, savePath),
-            parentId,
-            title: savePath,
-            contexts: ['link'],
-          });
-        }
+      }
+      for (const savePath of paths) {
+        browser.contextMenus.create({
+          id: makePathMenuId(instance.id, savePath),
+          parentId,
+          title: savePath,
+          contexts: ['link'],
+        });
       }
     }
   }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -51,3 +51,7 @@ export const basicAuthUsername = storage.defineItem<string>('local:basicAuthUser
 export const basicAuthPassword = storage.defineItem<string>('local:basicAuthPassword', {
   fallback: '',
 });
+
+export const savePaths = storage.defineItem<string[]>('local:savePaths', {
+  fallback: [],
+});

--- a/test/menu-id.test.ts
+++ b/test/menu-id.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { makeMenuId, makePathMenuId, parseMenuId } from '../lib/menu-id';
+
+describe('parseMenuId', () => {
+  test('round-trips a category target', () => {
+    expect(parseMenuId(makeMenuId('1', 'tv|shows'))).toEqual({
+      instanceId: '1',
+      category: 'tv|shows',
+    });
+  });
+
+  test('round-trips a save path target with | and backslashes', () => {
+    for (const savePath of ['D:\\Downloads\\Movies', '/data/a|b', '/plain']) {
+      expect(parseMenuId(makePathMenuId('42', savePath))).toEqual({
+        instanceId: '42',
+        category: '',
+        savePath,
+      });
+    }
+  });
+
+  test('returns null for unrelated ids', () => {
+    expect(parseMenuId('send-to-qui')).toBeNull();
+    expect(parseMenuId('instance-1')).toBeNull();
+    expect(parseMenuId('path|1')).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds a **Save paths** field in options so a torrent can be sent to a fixed path instead of a category. Each instance submenu lists the paths after the categories, and a path item sends `savepath` with no category. Path items also show in favorites-only mode; starring a path is not supported yet.

Closes #13

## How has this been tested?

Loaded the unpacked build in Chrome against a local stub of the qui API that logs every request body. A magnet link and a `.torrent` link sent through a path item each produced a `POST /api/instances/{id}/torrents` body with `savepath` set and no `category`, including a Windows path that contains `|`. A category item still sent `category` only. With favorites-only on and no favorites, the menu shows the path items alone.
