### PR TITLE
feat: add a Cross-seed in qui context menu with a picker tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Chrome extension (Manifest V3) that adds torrents to qBittorrent instances via a qui server. Right-click a magnet/torrent link, pick an instance and category from nested context menus, and receive a notification confirming the torrent was added. A second menu, "Cross-seed in qui", sends a `.torrent` link to qui's manual cross-seed flow through a picker tab.
+Chrome extension (Manifest V3) that adds torrents to qBittorrent instances via a qui server. Right-click a magnet/torrent link, pick an instance and category from nested context menus, and receive a notification confirming the torrent was added. A second menu, "Cross-seed in qui", sends a `.torrent` link to qui's manual cross-seed flow through a picker window.
 
 ## Commands
 
@@ -33,7 +33,7 @@ Built with **WXT** (Vite-based extension framework), **React 19**, **Tailwind CS
 - **`background.ts`** — Service worker. Registers context menus on install, handles menu clicks by calling the qui API, manages a 15-minute alarm-based cache refresh, and acts as the message passing hub.
 - **`popup/`** — Toolbar popup. Shows favorites (starred instance/category pairs) and connection status.
 - **`options/`** — Options page. Configures qui server URL, API key, host permissions, and favorites management.
-- **`cross-seed/`** — Picker tab opened by the "Cross-seed in qui" menu. Reads the pending payload from `chrome.storage.session`, lets the user pick the target torrent (ranked proposals, or a name search over the instance that pins any torrent through `pin-cross-seed-target`), category, and tags, then sends `apply-cross-seed` to the background.
+- **`cross-seed/`** — Picker window opened by the "Cross-seed in qui" menu. Reads the pending payload from `chrome.storage.session`, lets the user pick the target torrent (ranked proposals, or a name search over the instance that pins any torrent through `pin-cross-seed-target`), category, and tags, then sends `apply-cross-seed` to the background.
 
 ### Shared Libraries (`lib/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Built with **WXT** (Vite-based extension framework), **React 19**, **Tailwind CS
 - **`background.ts`** — Service worker. Registers context menus on install, handles menu clicks by calling the qui API, manages a 15-minute alarm-based cache refresh, and acts as the message passing hub.
 - **`popup/`** — Toolbar popup. Shows favorites (starred instance/category pairs) and connection status.
 - **`options/`** — Options page. Configures qui server URL, API key, host permissions, and favorites management.
-- **`cross-seed/`** — Picker tab opened by the "Cross-seed in qui" menu. Reads the pending payload from `chrome.storage.session`, lets the user pick the target torrent, category, and tags, then sends `apply-cross-seed` to the background.
+- **`cross-seed/`** — Picker tab opened by the "Cross-seed in qui" menu. Reads the pending payload from `chrome.storage.session`, lets the user pick the target torrent (ranked proposals, or a name search over the instance that pins any torrent through `pin-cross-seed-target`), category, and tags, then sends `apply-cross-seed` to the background.
 
 ### Shared Libraries (`lib/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Chrome extension (Manifest V3) that adds torrents to qBittorrent instances via a qui server. Right-click a magnet/torrent link, pick an instance and category from nested context menus, and receive a notification confirming the torrent was added.
+Chrome extension (Manifest V3) that adds torrents to qBittorrent instances via a qui server. Right-click a magnet/torrent link, pick an instance and category from nested context menus, and receive a notification confirming the torrent was added. A second menu, "Cross-seed in qui", sends a `.torrent` link to qui's manual cross-seed flow through a picker tab.
 
 ## Commands
 
@@ -33,14 +33,16 @@ Built with **WXT** (Vite-based extension framework), **React 19**, **Tailwind CS
 - **`background.ts`** — Service worker. Registers context menus on install, handles menu clicks by calling the qui API, manages a 15-minute alarm-based cache refresh, and acts as the message passing hub.
 - **`popup/`** — Toolbar popup. Shows favorites (starred instance/category pairs) and connection status.
 - **`options/`** — Options page. Configures qui server URL, API key, host permissions, and favorites management.
+- **`cross-seed/`** — Picker tab opened by the "Cross-seed in qui" menu. Reads the pending payload from `chrome.storage.session`, lets the user pick the target torrent, category, and tags, then sends `apply-cross-seed` to the background.
 
 ### Shared Libraries (`lib/`)
 
-- **`api.ts`** — ky-based HTTP client wrapping qui endpoints (`GET /api/instances`, `GET /api/instances/{id}/categories`, `POST /api/instances/{id}/torrents`).
+- **`api.ts`** — ky-based HTTP client wrapping qui endpoints (`GET /api/instances`, `GET /api/instances/{id}/categories`, `POST /api/instances/{id}/torrents`, `POST /api/cross-seed/manual/proposals`, `POST /api/cross-seed/manual/apply`). Error responses surface qui's `error` text.
 - **`cache.ts`** — Fetches and caches instances + categories to chrome.storage.local.
-- **`menus.ts`** — Builds nested context menu structure from cached data (favorites appear first).
+- **`menu-id.ts`** — Pure menu id helpers (`makeMenuId`, `makeCrossSeedMenuId`, `parseMenuId`). No wxt imports so tests can load it.
+- **`menus.ts`** — Builds nested context menu structure from cached data (favorites appear first). "Cross-seed in qui" lists every enabled instance and ignores `favoritesOnly`.
 - **`messaging.ts`** — Typed message passing between background, popup, and options.
-- **`storage.ts`** — Typed chrome.storage.local definitions (serverUrl, apiKey, favorites, cachedData).
+- **`storage.ts`** — Typed chrome.storage definitions: local (serverUrl, apiKey, favorites, cachedData) and session (crossSeedPending, the torrent payload plus proposals for the open picker).
 - **`permissions.ts`** — URL-to-origin conversion for host permission requests.
 
 ### Data Flow
@@ -54,7 +56,7 @@ Built with **WXT** (Vite-based extension framework), **React 19**, **Tailwind CS
 
 - **MV3 service worker**: No persistent state; all persistence via chrome.storage.local
 - **Context menus registered in `onInstalled`**: Menus persist across service worker restarts
-- **Menu item ID format**: `add|{instanceId}|{category}` (parsed on click)
+- **Menu item ID format**: `add|{instanceId}|{category}` or `cross-seed|{instanceId}|` (parsed on click)
 - **Path alias**: `@/*` maps to project root in imports
 - **CSS**: Tailwind v4 CSS-first config with Radix Themes dark mode via `@layer`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- Cross-seed: a **Cross-seed in qui** context-menu item for `.torrent` links (#11). It lists every enabled instance and opens a picker tab with the torrents qui ranks by file overlap. Pick a target, category, and tags, and qui adds the torrent pinned to that target with a full recheck. Needs qui 1.28.0 or newer. Magnet links are rejected because they carry no file list.
+- Cross-seed: a **Cross-seed in qui** context-menu item for `.torrent` links (#11). It lists every enabled instance and opens a picker tab with the torrents qui ranks by file overlap. Pick a target from the ranked list or search the instance by name for any other torrent, set category and tags, and qui adds the torrent pinned to that target with a full recheck. Needs qui 1.28.0 or newer. Magnet links are rejected because they carry no file list.
 
 ### Changed
 - Errors: notifications and the options page now show the error text qui returns instead of only the HTTP status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
+### Added
+- Cross-seed: a **Cross-seed in qui** context-menu item for `.torrent` links (#11). It lists every enabled instance and opens a picker tab with the torrents qui ranks by file overlap. Pick a target, category, and tags, and qui adds the torrent pinned to that target with a full recheck. Needs qui 1.28.0 or newer. Magnet links are rejected because they carry no file list.
+
 ### Changed
+- Errors: notifications and the options page now show the error text qui returns instead of only the HTTP status.
 - Permissions: drop the required `<all_urls>` host permission and the always-on content script (#3). Installation no longer warns about reading data on all websites.
 - Torrent files: fetch `.torrent` links inside the clicked tab with `activeTab` and `scripting`. The context-menu click grants both.
 - Server access: the qui server origin is now an optional host permission. Save in options requests it. Existing users see a **Grant access** button in options until they grant it. The popup and error notifications point to that button while it is missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- Cross-seed: a **Cross-seed in qui** context-menu item for `.torrent` links (#11). It lists every enabled instance and opens a picker tab with the torrents qui ranks by file overlap. Pick a target from the ranked list or search the instance by name for any other torrent, set category and tags, and qui adds the torrent pinned to that target with a full recheck. Needs qui 1.28.0 or newer. Magnet links are rejected because they carry no file list.
+- Cross-seed: a **Cross-seed in qui** context-menu item for `.torrent` links (#11). It lists every enabled instance and opens a picker window with the torrents qui ranks by file overlap. Pick a target from the ranked list or search the instance by name for any other torrent, set category and tags, and qui adds the torrent pinned to that target with a full recheck. Needs qui 1.28.0 or newer. Magnet links are rejected because they carry no file list.
 
 ### Changed
 - Errors: notifications and the options page now show the error text qui returns instead of only the HTTP status.

--- a/assets/cross-seed.css
+++ b/assets/cross-seed.css
@@ -1,0 +1,19 @@
+/* Preflight first so Radix layout props (padding, gap) win over its resets. */
+@layer tw_base, radix_ui, tw_utilities;
+
+@import "tailwindcss" layer(tw_base);
+@import "@radix-ui/themes/styles.css" layer(radix_ui);
+
+@theme {
+  --color-background: oklch(0.145 0 0);
+  --color-surface: oklch(0.274 0.006 286);
+  --color-text: oklch(0.985 0 0);
+  --color-muted: oklch(0.55 0 0);
+  --color-border: oklch(0.3 0.006 286);
+}
+
+body {
+  margin: 0;
+  background: var(--color-background);
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+}

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -5,6 +5,7 @@ import {
   addTorrentFile,
   getCrossSeedProposals,
   applyCrossSeed,
+  searchTorrents,
   type AddTorrentOptions,
 } from '@/lib/api';
 import type { ApiMessage, ApiResponse, FetchTorrentResponse, TorrentFileData } from '@/lib/messaging';
@@ -110,16 +111,29 @@ async function openCrossSeedPicker(
   }
 }
 
+async function loadPending(pendingId: string) {
+  const pending = await crossSeedPending.getValue();
+  if (pending?.id !== pendingId) {
+    throw new Error('This picker is stale. Right-click the torrent link again.');
+  }
+  return pending;
+}
+
+/** Re-rank proposals with targetHash forced into the list, and remember the result. */
+async function pinCrossSeedTarget(pendingId: string, targetHash: string) {
+  const pending = await loadPending(pendingId);
+  const match = await getCrossSeedProposals(pending.instanceId, pending.file, targetHash);
+  await crossSeedPending.setValue({ ...pending, match });
+  return match;
+}
+
 async function handleApplyCrossSeed(
   pendingId: string,
   targetHash: string,
   category: string | undefined,
   tags: string[],
 ): Promise<void> {
-  const pending = await crossSeedPending.getValue();
-  if (pending?.id !== pendingId) {
-    throw new Error('This picker is stale. Right-click the torrent link again.');
-  }
+  const pending = await loadPending(pendingId);
   const target = pending.match.proposals.find((p) => p.hash === targetHash);
   try {
     await applyCrossSeed(pending.instanceId, pending.file, targetHash, category, tags);
@@ -202,6 +216,12 @@ export default defineBackground(() => {
                 message.category,
                 await getTorrentOptions(),
               );
+              break;
+            case 'search-torrents':
+              data = await searchTorrents(message.instanceId, message.query);
+              break;
+            case 'pin-cross-seed-target':
+              data = await pinCrossSeedTarget(message.pendingId, message.targetHash);
               break;
             case 'apply-cross-seed':
               await handleApplyCrossSeed(message.pendingId, message.targetHash, message.category, message.tags);

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -105,7 +105,12 @@ async function openCrossSeedPicker(
     const file = await fetchTorrentFromTab(info, tab);
     const match = await getCrossSeedProposals(instanceId, file);
     await crossSeedPending.setValue({ id: crypto.randomUUID(), instanceId, instanceName, file, match });
-    await browser.tabs.create({ url: browser.runtime.getURL('/cross-seed.html') });
+    await browser.windows.create({
+      url: browser.runtime.getURL('/cross-seed.html'),
+      type: 'popup',
+      width: 600,
+      height: 680,
+    });
   } catch (err) {
     notify('Failed to Add Cross-seed', errorMessage(err));
   }

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,9 +1,18 @@
-import { getInstances, getCategories, addTorrent, addTorrentFile, type AddTorrentOptions } from '@/lib/api';
-import type { ApiMessage, ApiResponse, FetchTorrentResponse } from '@/lib/messaging';
+import {
+  getInstances,
+  getCategories,
+  addTorrent,
+  addTorrentFile,
+  getCrossSeedProposals,
+  applyCrossSeed,
+  type AddTorrentOptions,
+} from '@/lib/api';
+import type { ApiMessage, ApiResponse, FetchTorrentResponse, TorrentFileData } from '@/lib/messaging';
 import { refreshCache, loadCachedData } from '@/lib/cache';
-import { rebuildMenus, parseMenuId } from '@/lib/menus';
+import { rebuildMenus } from '@/lib/menus';
+import { parseMenuId } from '@/lib/menu-id';
 import { fetchTorrentInPage } from '@/lib/torrent-file';
-import { cachedData, addPaused, skipRecheck } from '@/lib/storage';
+import { cachedData, addPaused, skipRecheck, crossSeedPending } from '@/lib/storage';
 import { isMagnetUrl } from '@/lib/url';
 
 const CACHE_ALARM = 'refresh-cache';
@@ -15,6 +24,114 @@ async function getTorrentOptions(): Promise<AddTorrentOptions> {
     skipRecheck.getValue(),
   ]);
   return { paused, skipChecking };
+}
+
+function notify(title: string, message: string): void {
+  browser.notifications.create(`${title}-${Date.now()}`, {
+    type: 'basic',
+    iconUrl: browser.runtime.getURL('/icon-128.png'),
+    title,
+    message,
+  });
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : 'Unknown error';
+}
+
+/**
+ * Fetch a .torrent URL inside the clicked tab to use the page's
+ * cookies/session. The context-menu click grants activeTab.
+ */
+async function fetchTorrentFromTab(
+  info: Browser.contextMenus.OnClickData,
+  tab: Browser.tabs.Tab | undefined,
+): Promise<TorrentFileData> {
+  const tabId = tab?.id;
+  if (!tabId || !info.linkUrl) {
+    throw new Error('No tab context for fetching torrent');
+  }
+
+  let response: FetchTorrentResponse | undefined;
+  try {
+    const [injection] = await browser.scripting.executeScript({
+      target: { tabId, frameIds: [info.frameId ?? 0] },
+      func: fetchTorrentInPage,
+      args: [info.linkUrl],
+    });
+    response = injection?.result as FetchTorrentResponse | undefined;
+  } catch (error) {
+    // Restricted pages (chrome://, the Web Store, PDF viewer) refuse injection.
+    throw new Error(`Cannot read this page to fetch the torrent file: ${error}`);
+  }
+  if (!response?.success) {
+    throw new Error(response?.error ?? 'Could not fetch the torrent file from this tab');
+  }
+  return response.data;
+}
+
+async function handleAdd(
+  info: Browser.contextMenus.OnClickData,
+  tab: Browser.tabs.Tab | undefined,
+  instanceId: string,
+  instanceName: string,
+  category: string,
+): Promise<void> {
+  const url = info.linkUrl!;
+  try {
+    const options = await getTorrentOptions();
+    if (isMagnetUrl(url)) {
+      await addTorrent(instanceId, url, category, options);
+    } else {
+      await addTorrentFile(instanceId, await fetchTorrentFromTab(info, tab), category, options);
+    }
+    notify('Torrent Added', `Added to ${instanceName}${category ? ' / ' + category : ''}`);
+  } catch (err) {
+    notify('Failed to Add Torrent', errorMessage(err));
+  }
+}
+
+async function openCrossSeedPicker(
+  info: Browser.contextMenus.OnClickData,
+  tab: Browser.tabs.Tab | undefined,
+  instanceId: string,
+  instanceName: string,
+): Promise<void> {
+  try {
+    if (isMagnetUrl(info.linkUrl!)) {
+      throw new Error('Cross-seed needs a .torrent file, magnet links have no file list');
+    }
+    const file = await fetchTorrentFromTab(info, tab);
+    const match = await getCrossSeedProposals(instanceId, file);
+    await crossSeedPending.setValue({ id: crypto.randomUUID(), instanceId, instanceName, file, match });
+    await browser.tabs.create({ url: browser.runtime.getURL('/cross-seed.html') });
+  } catch (err) {
+    notify('Failed to Add Cross-seed', errorMessage(err));
+  }
+}
+
+async function handleApplyCrossSeed(
+  pendingId: string,
+  targetHash: string,
+  category: string | undefined,
+  tags: string[],
+): Promise<void> {
+  const pending = await crossSeedPending.getValue();
+  if (pending?.id !== pendingId) {
+    throw new Error('This picker is stale. Right-click the torrent link again.');
+  }
+  const target = pending.match.proposals.find((p) => p.hash === targetHash);
+  try {
+    await applyCrossSeed(pending.instanceId, pending.file, targetHash, category, tags);
+  } catch (err) {
+    notify('Failed to Add Cross-seed', errorMessage(err));
+    throw err;
+  }
+  await crossSeedPending.removeValue();
+  notify(
+    'Cross-seed Added',
+    `Added to ${pending.instanceName} as cross-seed of ${target?.name ?? targetHash}`,
+  );
 }
 
 export default defineBackground(() => {
@@ -42,7 +159,7 @@ export default defineBackground(() => {
     }
   });
 
-  // --- contextMenus.onClicked: add torrent and notify ---
+  // --- contextMenus.onClicked: add torrent or open the cross-seed picker ---
   browser.contextMenus.onClicked.addListener(async (info, tab) => {
     if (!info.linkUrl) return;
 
@@ -54,56 +171,14 @@ export default defineBackground(() => {
     const instance = cache.instances.find((i) => String(i.id) === parsed.instanceId);
     const instanceName = instance?.name ?? parsed.instanceId;
 
-    try {
-      const options = await getTorrentOptions();
-
-      if (isMagnetUrl(info.linkUrl)) {
-        // Magnet links can be sent directly to qui
-        await addTorrent(parsed.instanceId, info.linkUrl, parsed.category, options);
-      } else {
-        // .torrent URLs: fetch inside the clicked tab to use the page's
-        // cookies/session. The context-menu click grants activeTab.
-        const tabId = tab?.id;
-        if (!tabId) {
-          throw new Error('No tab context for fetching torrent');
-        }
-
-        let response: FetchTorrentResponse | undefined;
-        try {
-          const [injection] = await browser.scripting.executeScript({
-            target: { tabId, frameIds: [info.frameId ?? 0] },
-            func: fetchTorrentInPage,
-            args: [info.linkUrl],
-          });
-          response = injection?.result as FetchTorrentResponse | undefined;
-        } catch (error) {
-          // Restricted pages (chrome://, the Web Store, PDF viewer) refuse injection.
-          throw new Error(`Cannot read this page to fetch the torrent file: ${error}`);
-        }
-        if (!response?.success) {
-          throw new Error(response?.error ?? 'Could not fetch the torrent file from this tab');
-        }
-
-        await addTorrentFile(parsed.instanceId, response.data, parsed.category, options);
-      }
-
-      browser.notifications.create(`success-${Date.now()}`, {
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icon-128.png'),
-        title: 'Torrent Added',
-        message: `Added to ${instanceName}${parsed.category ? ' / ' + parsed.category : ''}`,
-      });
-    } catch (err) {
-      browser.notifications.create(`error-${Date.now()}`, {
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icon-128.png'),
-        title: 'Failed to Add Torrent',
-        message: err instanceof Error ? err.message : 'Unknown error',
-      });
+    if (parsed.action === 'cross-seed') {
+      await openCrossSeedPicker(info, tab, parsed.instanceId, instanceName);
+    } else {
+      await handleAdd(info, tab, parsed.instanceId, instanceName, parsed.category);
     }
   });
 
-  // --- onMessage: handle messages from options page ---
+  // --- onMessage: handle messages from extension pages ---
   browser.runtime.onMessage.addListener(
     (
       message: ApiMessage,
@@ -128,6 +203,10 @@ export default defineBackground(() => {
                 await getTorrentOptions(),
               );
               break;
+            case 'apply-cross-seed':
+              await handleApplyCrossSeed(message.pendingId, message.targetHash, message.category, message.tags);
+              data = true;
+              break;
             case 'test-connection':
               data = await getInstances();
               break;
@@ -144,10 +223,7 @@ export default defineBackground(() => {
           }
           sendResponse({ success: true, data });
         } catch (err) {
-          sendResponse({
-            success: false,
-            error: err instanceof Error ? err.message : 'Unknown error',
-          });
+          sendResponse({ success: false, error: errorMessage(err) });
         }
       })();
 

--- a/entrypoints/cross-seed/App.tsx
+++ b/entrypoints/cross-seed/App.tsx
@@ -131,7 +131,7 @@ export default function App() {
   const categoryOptions = Array.from(new Set([...categories, category].filter(Boolean)));
 
   return (
-    <Box p="6" style={{ maxWidth: 720, margin: '0 auto', color: 'var(--color-text)' }}>
+    <Box p="6" style={{ color: 'var(--color-text)' }}>
       <Heading size="5" mb="1">Cross-seed in {pending.instanceName}</Heading>
       <Text size="2" style={{ color: 'var(--color-muted)' }}>
         {pending.match.source_name} · {formatBytes(pending.match.source_size)} · {pending.match.source_file_count} files
@@ -143,7 +143,7 @@ export default function App() {
         </Card>
       )}
 
-      <Text as="p" size="2" weight="medium" mt="5" mb="2">Pick another torrent by name</Text>
+      <Text as="p" size="2" weight="medium" mt="6" mb="2">Pick another torrent by name</Text>
       <TextField.Root
         value={query}
         onChange={(e) => setQuery(e.target.value)}
@@ -162,7 +162,7 @@ export default function App() {
 
       {proposals.length > 0 && (
         <>
-          <Text as="p" size="2" weight="medium" mt="5" mb="2">Cross-seed of</Text>
+          <Text as="p" size="2" weight="medium" mt="6" mb="2">Cross-seed of</Text>
           <RadioCards.Root
             value={targetHash}
             onValueChange={(hash) => {
@@ -184,7 +184,7 @@ export default function App() {
             ))}
           </RadioCards.Root>
 
-          <Flex direction="column" gap="3" mt="5">
+          <Flex direction="column" gap="4" mt="6">
             <label>
               <Text as="div" size="2" weight="medium" mb="1">Category</Text>
               {pinned_category ? (
@@ -195,7 +195,7 @@ export default function App() {
                   onChange={(e) => setCategory(e.target.value)}
                   style={{
                     width: '100%',
-                    padding: '6px 8px',
+                    padding: '8px 10px',
                     borderRadius: 6,
                     background: 'var(--color-surface)',
                     color: 'var(--color-text)',
@@ -219,7 +219,7 @@ export default function App() {
             </label>
           </Flex>
 
-          <Flex justify="end" mt="5">
+          <Flex justify="end" mt="6">
             <Button onClick={apply} disabled={busy || !targetHash} loading={busy}>
               Add cross-seed
             </Button>

--- a/entrypoints/cross-seed/App.tsx
+++ b/entrypoints/cross-seed/App.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import { Box, Button, Card, Flex, Heading, RadioCards, Text, TextField } from '@radix-ui/themes';
+import { browser } from 'wxt/browser';
+import { sendToBackground } from '@/lib/messaging';
+import { cachedData, crossSeedPending, type CrossSeedPending } from '@/lib/storage';
+
+function formatBytes(bytes: number): string {
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(i === 0 ? 0 : 2)} ${units[i]}`;
+}
+
+export default function App() {
+  const [pending, setPending] = useState<CrossSeedPending | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [targetHash, setTargetHash] = useState('');
+  const [category, setCategory] = useState('');
+  const [tags, setTags] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      const [p, cache] = await Promise.all([crossSeedPending.getValue(), cachedData.getValue()]);
+      if (p) {
+        setCategories((cache.categoriesByInstance[p.instanceId] ?? []).map((c) => c.name));
+        const top = p.match.proposals[0];
+        if (top) {
+          setTargetHash(top.hash);
+          setCategory(top.category);
+        }
+        setTags(p.match.default_tags.join(', '));
+      }
+      setPending(p);
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  async function apply() {
+    if (!pending) return;
+    setBusy(true);
+    setError('');
+    try {
+      await sendToBackground({
+        type: 'apply-cross-seed',
+        pendingId: pending.id,
+        targetHash,
+        category: pending.match.pinned_category ? undefined : category,
+        tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+      });
+      const tab = await browser.tabs.getCurrent();
+      if (tab?.id) await browser.tabs.remove(tab.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      setBusy(false);
+    }
+  }
+
+  if (loading) {
+    return <Text size="2" style={{ color: 'var(--color-muted)', padding: 24, display: 'block' }}>Loading...</Text>;
+  }
+
+  if (!pending) {
+    return (
+      <Box p="6">
+        <Text size="2" style={{ color: 'var(--color-muted)' }}>
+          Nothing to cross-seed. Right-click a .torrent link and pick Cross-seed in qui.
+        </Text>
+      </Box>
+    );
+  }
+
+  const { proposals, pinned_category } = pending.match;
+  // The selected proposal's category may be missing from the cache; offer it anyway.
+  const categoryOptions = Array.from(new Set([...categories, category].filter(Boolean)));
+
+  return (
+    <Box p="6" style={{ maxWidth: 720, margin: '0 auto', color: 'var(--color-text)' }}>
+      <Heading size="5" mb="1">Cross-seed in {pending.instanceName}</Heading>
+      <Text size="2" style={{ color: 'var(--color-muted)' }}>
+        {pending.match.source_name} · {formatBytes(pending.match.source_size)} · {pending.match.source_file_count} files
+      </Text>
+
+      {proposals.length === 0 ? (
+        <Card mt="5">
+          <Text size="2">No torrent on this instance shares files with this one.</Text>
+        </Card>
+      ) : (
+        <>
+          <Text as="p" size="2" weight="medium" mt="5" mb="2">Cross-seed of</Text>
+          <RadioCards.Root
+            value={targetHash}
+            onValueChange={(hash) => {
+              setTargetHash(hash);
+              setCategory(proposals.find((p) => p.hash === hash)?.category ?? '');
+            }}
+            columns="1"
+            gap="2"
+          >
+            {proposals.map((p) => (
+              <RadioCards.Item key={p.hash} value={p.hash}>
+                <Flex direction="column" width="100%" gap="1">
+                  <Text size="2" weight="medium" style={{ wordBreak: 'break-all' }}>{p.name}</Text>
+                  <Text size="1" style={{ color: 'var(--color-muted)' }}>
+                    {Math.round(p.overlap_fraction * 100)}% overlap · {formatBytes(p.size)}{p.category ? ` · ${p.category}` : ''}
+                  </Text>
+                </Flex>
+              </RadioCards.Item>
+            ))}
+          </RadioCards.Root>
+
+          <Flex direction="column" gap="3" mt="5">
+            <label>
+              <Text as="div" size="2" weight="medium" mb="1">Category</Text>
+              {pinned_category ? (
+                <Text size="2" style={{ color: 'var(--color-muted)' }}>{pinned_category} (pinned by qui)</Text>
+              ) : (
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  style={{
+                    width: '100%',
+                    padding: '6px 8px',
+                    borderRadius: 6,
+                    background: 'var(--color-surface)',
+                    color: 'var(--color-text)',
+                    border: '1px solid var(--color-border)',
+                  }}
+                >
+                  <option value="">(No category)</option>
+                  {categoryOptions.map((name) => (
+                    <option key={name} value={name}>{name}</option>
+                  ))}
+                </select>
+              )}
+            </label>
+            <label>
+              <Text as="div" size="2" weight="medium" mb="1">Tags</Text>
+              <TextField.Root
+                value={tags}
+                onChange={(e) => setTags(e.target.value)}
+                placeholder="comma, separated"
+              />
+            </label>
+          </Flex>
+
+          {error && (
+            <Text as="p" size="2" color="red" mt="3">{error}</Text>
+          )}
+
+          <Flex justify="end" mt="5">
+            <Button onClick={apply} disabled={busy || !targetHash} loading={busy}>
+              Add cross-seed
+            </Button>
+          </Flex>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/entrypoints/cross-seed/App.tsx
+++ b/entrypoints/cross-seed/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Box, Button, Card, Flex, Heading, RadioCards, Text, TextField } from '@radix-ui/themes';
+import type { CrossSeedProposals, TorrentSummary } from '@/lib/api';
 import { browser } from 'wxt/browser';
 import { sendToBackground } from '@/lib/messaging';
 import { cachedData, crossSeedPending, type CrossSeedPending } from '@/lib/storage';
@@ -24,6 +25,8 @@ export default function App() {
   const [tags, setTags] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<TorrentSummary[]>([]);
 
   useEffect(() => {
     async function load() {
@@ -42,6 +45,52 @@ export default function App() {
     }
     load();
   }, []);
+
+  // Debounced name search on the instance, for targets the ranking did not surface.
+  useEffect(() => {
+    if (!pending || query.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    let stale = false;
+    const timer = setTimeout(async () => {
+      try {
+        const found = await sendToBackground<TorrentSummary[]>({
+          type: 'search-torrents',
+          instanceId: pending.instanceId,
+          query: query.trim(),
+        });
+        if (!stale) setResults(found);
+      } catch (err) {
+        if (!stale) setError(err instanceof Error ? err.message : 'Unknown error');
+      }
+    }, 300);
+    return () => {
+      stale = true;
+      clearTimeout(timer);
+    };
+  }, [query, pending]);
+
+  async function pinTarget(torrent: TorrentSummary) {
+    if (!pending) return;
+    setBusy(true);
+    setError('');
+    try {
+      const match = await sendToBackground<CrossSeedProposals>({
+        type: 'pin-cross-seed-target',
+        pendingId: pending.id,
+        targetHash: torrent.hash,
+      });
+      setPending({ ...pending, match });
+      setTargetHash(torrent.hash);
+      setCategory(torrent.category);
+      setQuery('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setBusy(false);
+    }
+  }
 
   async function apply() {
     if (!pending) return;
@@ -88,11 +137,30 @@ export default function App() {
         {pending.match.source_name} · {formatBytes(pending.match.source_size)} · {pending.match.source_file_count} files
       </Text>
 
-      {proposals.length === 0 ? (
+      {proposals.length === 0 && (
         <Card mt="5">
           <Text size="2">No torrent on this instance shares files with this one.</Text>
         </Card>
-      ) : (
+      )}
+
+      <Text as="p" size="2" weight="medium" mt="5" mb="2">Pick another torrent by name</Text>
+      <TextField.Root
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search torrents on this instance"
+      />
+      {results.length > 0 && (
+        <Flex direction="column" gap="1" mt="2">
+          {results.map((t) => (
+            <Button key={t.hash} variant="soft" color="gray" disabled={busy} onClick={() => pinTarget(t)} style={{ justifyContent: 'flex-start', height: 'auto', padding: '6px 10px' }}>
+              <Text size="2" style={{ wordBreak: 'break-all', textAlign: 'left' }}>{t.name}</Text>
+              <Text size="1" style={{ color: 'var(--color-muted)', whiteSpace: 'nowrap' }}>{formatBytes(t.size)}</Text>
+            </Button>
+          ))}
+        </Flex>
+      )}
+
+      {proposals.length > 0 && (
         <>
           <Text as="p" size="2" weight="medium" mt="5" mb="2">Cross-seed of</Text>
           <RadioCards.Root
@@ -151,16 +219,16 @@ export default function App() {
             </label>
           </Flex>
 
-          {error && (
-            <Text as="p" size="2" color="red" mt="3">{error}</Text>
-          )}
-
           <Flex justify="end" mt="5">
             <Button onClick={apply} disabled={busy || !targetHash} loading={busy}>
               Add cross-seed
             </Button>
           </Flex>
         </>
+      )}
+
+      {error && (
+        <Text as="p" size="2" color="red" mt="3">{error}</Text>
       )}
     </Box>
   );

--- a/entrypoints/cross-seed/index.html
+++ b/entrypoints/cross-seed/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cross-seed in qui</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/entrypoints/cross-seed/main.tsx
+++ b/entrypoints/cross-seed/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import '@/assets/popup.css';
+import { Theme } from '@radix-ui/themes';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Theme appearance="dark" accentColor="blue" grayColor="slate" radius="medium">
+      <App />
+    </Theme>
+  </React.StrictMode>,
+);

--- a/entrypoints/cross-seed/main.tsx
+++ b/entrypoints/cross-seed/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-import '@/assets/popup.css';
+import '@/assets/cross-seed.css';
 import { Theme } from '@radix-ui/themes';
 
 createRoot(document.getElementById('root')!).render(

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -37,6 +37,17 @@ async function getClient() {
       statusCodes: [408, 500, 502, 503, 504],
     },
     hooks: {
+      beforeError: [
+        async (error) => {
+          // qui answers errors with {"error": "..."}; surface that text and
+          // keep the status so formatConnectionError can still match on it.
+          const body = await error.response.clone().json().catch(() => null) as { error?: string } | null;
+          if (body?.error) {
+            error.message = `HTTP ${error.response.status}: ${body.error}`;
+          }
+          return error;
+        },
+      ],
       beforeRequest: [
         (request) => {
           request.headers.set('X-API-Key', key);
@@ -110,4 +121,69 @@ export async function addTorrentFile(
   form.append('torrent', blobFromTorrentFile(fileData), 'file.torrent');
 
   return client.post(`api/instances/${instanceId}/torrents`, { body: form }).json();
+}
+
+export interface CrossSeedProposal {
+  hash: string;
+  name: string;
+  size: number;
+  category: string;
+  effective_save_path: string;
+  overlap_bytes: number;
+  overlap_fraction: number;
+}
+
+export interface CrossSeedProposals {
+  source_name: string;
+  source_size: number;
+  source_file_count: number;
+  default_tags: string[];
+  pinned_category: string;
+  proposals: CrossSeedProposal[];
+}
+
+interface CrossSeedResponse {
+  success: boolean;
+  results?: { status: string; message?: string }[];
+}
+
+/** Rank torrents on the instance by file-size overlap with the given .torrent. */
+export async function getCrossSeedProposals(
+  instanceId: string,
+  fileData: TorrentFileData,
+): Promise<CrossSeedProposals> {
+  const client = await getClient();
+  const raw = await client
+    .post('api/cross-seed/manual/proposals', {
+      json: { instance_id: Number(instanceId), torrent_data: fileData.base64 },
+    })
+    .json<CrossSeedProposals>();
+  // Go serializes nil slices as null.
+  return { ...raw, default_tags: raw.default_tags ?? [], proposals: raw.proposals ?? [] };
+}
+
+/** Add the .torrent pinned to targetHash. qui always runs a full recheck. */
+export async function applyCrossSeed(
+  instanceId: string,
+  fileData: TorrentFileData,
+  targetHash: string,
+  category: string | undefined,
+  tags: string[],
+): Promise<void> {
+  const client = await getClient();
+  const result = await client
+    .post('api/cross-seed/manual/apply', {
+      json: {
+        instance_id: Number(instanceId),
+        torrent_data: fileData.base64,
+        target_hash: targetHash,
+        category: category || undefined,
+        tags: tags.length ? tags : undefined,
+      },
+    })
+    .json<CrossSeedResponse>();
+  if (!result.success) {
+    const first = result.results?.[0];
+    throw new Error(first?.message || first?.status || 'Cross-seed was not added');
+  }
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -147,15 +147,35 @@ interface CrossSeedResponse {
   results?: { status: string; message?: string }[];
 }
 
-/** Rank torrents on the instance by file-size overlap with the given .torrent. */
+export interface TorrentSummary {
+  hash: string;
+  name: string;
+  size: number;
+  category: string;
+}
+
+/** Search torrents on an instance by name. Used to pick a cross-seed target by hand. */
+export async function searchTorrents(instanceId: string, query: string): Promise<TorrentSummary[]> {
+  const client = await getClient();
+  const raw = await client
+    .get(`api/instances/${instanceId}/torrents`, { searchParams: { search: query, limit: 20 } })
+    .json<{ torrents: TorrentSummary[] | null }>();
+  return (raw.torrents ?? []).map(({ hash, name, size, category }) => ({ hash, name, size, category }));
+}
+
+/**
+ * Rank torrents on the instance by file-size overlap with the given .torrent.
+ * targetHash, when set, is always included in the proposals, even at zero overlap.
+ */
 export async function getCrossSeedProposals(
   instanceId: string,
   fileData: TorrentFileData,
+  targetHash?: string,
 ): Promise<CrossSeedProposals> {
   const client = await getClient();
   const raw = await client
     .post('api/cross-seed/manual/proposals', {
-      json: { instance_id: Number(instanceId), torrent_data: fileData.base64 },
+      json: { instance_id: Number(instanceId), torrent_data: fileData.base64, target_hash: targetHash },
     })
     .json<CrossSeedProposals>();
   // Go serializes nil slices as null.

--- a/lib/menu-id.ts
+++ b/lib/menu-id.ts
@@ -1,0 +1,20 @@
+// Pure menu id helpers. No wxt imports so tests can load this file directly.
+export type MenuAction = 'add' | 'cross-seed';
+
+export function makeMenuId(instanceId: string, category: string): string {
+  return `add|${instanceId}|${category}`;
+}
+
+export function makeCrossSeedMenuId(instanceId: string): string {
+  return `cross-seed|${instanceId}|`;
+}
+
+export function parseMenuId(
+  menuItemId: string,
+): { action: MenuAction; instanceId: string; category: string } | null {
+  const [action, instanceId, ...rest] = String(menuItemId).split('|');
+  if ((action !== 'add' && action !== 'cross-seed') || !rest.length) {
+    return null;
+  }
+  return { action, instanceId, category: rest.join('|') };
+}

--- a/lib/menus.ts
+++ b/lib/menus.ts
@@ -1,26 +1,7 @@
 import { loadCachedData } from '@/lib/cache';
-import { favorites, favoritesOnly, enabledInstances, type Favorite } from '@/lib/storage';
-
-export function makeMenuId(instanceId: string, category: string): string {
-  return `add|${instanceId}|${category}`;
-}
-
-export function parseMenuId(
-  menuItemId: string,
-): { instanceId: string; category: string } | null {
-  if (typeof menuItemId !== 'string' || !menuItemId.startsWith('add|')) {
-    return null;
-  }
-  const firstSep = menuItemId.indexOf('|');
-  const secondSep = menuItemId.indexOf('|', firstSep + 1);
-  if (secondSep === -1) {
-    return null;
-  }
-  return {
-    instanceId: menuItemId.slice(firstSep + 1, secondSep),
-    category: menuItemId.slice(secondSep + 1),
-  };
-}
+import { favorites, favoritesOnly, enabledInstances, type CacheData, type Favorite } from '@/lib/storage';
+import type { Instance } from '@/lib/api';
+import { makeMenuId, makeCrossSeedMenuId } from '@/lib/menu-id';
 
 function isStarred(
   favs: Favorite[],
@@ -68,6 +49,43 @@ export async function rebuildMenus(): Promise<void> {
     return;
   }
 
+  buildSendMenu(cache, selectedInstances, favs, onlyFavs);
+  buildCrossSeedMenu(selectedInstances);
+}
+
+function buildCrossSeedMenu(selectedInstances: Instance[]): void {
+  // Same collapse rule as "Send to qui": one instance means the top-level
+  // item is the action itself.
+  if (selectedInstances.length === 1) {
+    browser.contextMenus.create({
+      id: makeCrossSeedMenuId(selectedInstances[0].id),
+      title: 'Cross-seed in qui',
+      contexts: ['link'],
+    });
+    return;
+  }
+
+  browser.contextMenus.create({
+    id: 'cross-seed-in-qui',
+    title: 'Cross-seed in qui',
+    contexts: ['link'],
+  });
+  for (const instance of selectedInstances) {
+    browser.contextMenus.create({
+      id: makeCrossSeedMenuId(instance.id),
+      parentId: 'cross-seed-in-qui',
+      title: instance.name,
+      contexts: ['link'],
+    });
+  }
+}
+
+function buildSendMenu(
+  cache: CacheData,
+  selectedInstances: Instance[],
+  favs: Favorite[],
+  onlyFavs: boolean,
+): void {
   if (onlyFavs && favs.length === 0) {
     browser.contextMenus.create({
       id: 'qui-no-favorites',

--- a/lib/messaging.ts
+++ b/lib/messaging.ts
@@ -6,7 +6,8 @@ export type ApiMessage =
   | { type: 'add-torrent'; instanceId: string; urls: string; category: string }
   | { type: 'test-connection' }
   | { type: 'refresh-cache' }
-  | { type: 'get-cached-data' };
+  | { type: 'get-cached-data' }
+  | { type: 'apply-cross-seed'; pendingId: string; targetHash: string; category?: string; tags: string[] };
 
 export type TorrentFileData = {
   // ponytail: base64, not ArrayBuffer — executeScript results are

--- a/lib/messaging.ts
+++ b/lib/messaging.ts
@@ -7,6 +7,8 @@ export type ApiMessage =
   | { type: 'test-connection' }
   | { type: 'refresh-cache' }
   | { type: 'get-cached-data' }
+  | { type: 'search-torrents'; instanceId: string; query: string }
+  | { type: 'pin-cross-seed-target'; pendingId: string; targetHash: string }
   | { type: 'apply-cross-seed'; pendingId: string; targetHash: string; category?: string; tags: string[] };
 
 export type TorrentFileData = {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,5 +1,6 @@
 import { storage } from 'wxt/utils/storage';
-import type { Instance, Category } from '@/lib/api';
+import type { Instance, Category, CrossSeedProposals } from '@/lib/api';
+import type { TorrentFileData } from '@/lib/messaging';
 
 export interface Favorite {
   instanceId: string;
@@ -50,4 +51,19 @@ export const basicAuthUsername = storage.defineItem<string>('local:basicAuthUser
 
 export const basicAuthPassword = storage.defineItem<string>('local:basicAuthPassword', {
   fallback: '',
+});
+
+export interface CrossSeedPending {
+  // Ties an apply to the payload the picker was opened for.
+  id: string;
+  instanceId: string;
+  instanceName: string;
+  file: TorrentFileData;
+  match: CrossSeedProposals;
+}
+
+// Session area: the torrent payload never touches disk and dies with the
+// browser. ponytail: one pending slot, the newest right-click wins.
+export const crossSeedPending = storage.defineItem<CrossSeedPending | null>('session:crossSeedPending', {
+  fallback: null,
 });

--- a/test/menu-id.test.ts
+++ b/test/menu-id.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { makeMenuId, makeCrossSeedMenuId, parseMenuId } from '../lib/menu-id';
+
+describe('parseMenuId', () => {
+  test('round-trips add ids, keeping separators inside the category', () => {
+    expect(parseMenuId(makeMenuId('3', 'tv|shows'))).toEqual({
+      action: 'add',
+      instanceId: '3',
+      category: 'tv|shows',
+    });
+  });
+
+  test('round-trips cross-seed ids', () => {
+    expect(parseMenuId(makeCrossSeedMenuId('3'))).toEqual({
+      action: 'cross-seed',
+      instanceId: '3',
+      category: '',
+    });
+  });
+
+  test('rejects unrelated ids', () => {
+    expect(parseMenuId('send-to-qui')).toBeNull();
+    expect(parseMenuId('instance-3')).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds a "Cross-seed in qui" context-menu item for `.torrent` links so a torrent can be added as a cross-seed of one already in the client through qui's manual match API (qui 1.28.0 or newer).

The background fetches the file in the clicked tab, asks qui for ranked target proposals, keeps the payload in `chrome.storage.session`, and opens a picker window. The picker shows the proposals with overlap percent, a name search over the instance for any other target, a category select (or the pinned category as read-only text), and editable tags. Apply pins the torrent to the chosen target and qui runs a full recheck. Magnet links get an error notification because they carry no file list.

Error responses from qui now surface their `error` text in notifications and the options page.

Closes #11

## How has this been tested?

Live against qui `develop` on the media server with a synthetic `.torrent` that mirrors a real torrent's file sizes. The picker opened with the target at 100% overlap, apply added the torrent pinned to it (qui.log: `Manual match: applying against user-chosen target`, recheck failed as expected with fake pieces), a second apply showed qui's "Torrent already exists in this instance" text and left the picker open, and the magnet gate showed its error without reaching qui. The name search listed results and pinning one added it to the proposals list with its overlap; it was not applied against a different target.