### PR TITLE
ci: review with Opus 5, 100 turns, owner PRs only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only review PRs from the repository owner. External and Dependabot PRs are skipped.
+    if: github.event.pull_request.user.login == 's0up4200'
 
     runs-on: ubuntu-latest
     permissions:
@@ -40,6 +37,8 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           claude_args: |
+            --model claude-opus-5
+            --max-turns 100
             --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),Bash(git show:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Cross-seed: a **Cross-seed in qui** context-menu item for `.torrent` links (#11). It lists every enabled instance and opens a picker window with the torrents qui ranks by file overlap. Pick a target from the ranked list or search the instance by name for any other torrent, set category and tags, and qui adds the torrent pinned to that target with a full recheck. Needs qui 1.28.0 or newer. Magnet links are rejected because they carry no file list.
 
 ### Changed
+- CI: the Claude review workflow uses Opus 5 with a 100-turn limit and runs only on PRs from the repository owner.
 - CI: the Claude review workflow can post its review comment. It ran on every PR but was denied write access and the `gh pr comment` tool, so it never posted.
 - CI runs `bun test` before the build. Dependabot checks GitHub Actions and bun dependencies weekly.
 - Errors: notifications and the options page now show the error text qui returns instead of only the HTTP status.


### PR DESCRIPTION
Sets the Claude review job to Opus 5 with a 100-turn limit and runs it only on PRs opened by the repository owner. External and Dependabot PRs skip it.

## How has this been tested?

The action skips runs where the workflow file differs from `main`, so the first real run is on the next owner PR after merge.