### PR TITLE
ci: review only the new commits on later pushes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
@@ -26,10 +20,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
-      - name: Run Claude Code Review
-        id: claude-review
+      # First open: the code-review plugin reviews the whole PR.
+      - name: Full review
+        if: github.event.action != 'synchronize'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -40,6 +35,28 @@ jobs:
             --model claude-opus-5
             --max-turns 100
             --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),Bash(git show:*)"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
 
+      # Later pushes: review only the commits in this push.
+      - name: Incremental review
+        if: github.event.action == 'synchronize'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review the new commits pushed to pull request ${{ github.repository }}#${{ github.event.pull_request.number }}.
+
+            Previous head: ${{ github.event.before }}
+            New head: ${{ github.event.after }}
+
+            Steps:
+            1. Run `gh pr view ${{ github.event.pull_request.number }} --json state,isDraft`. Stop if the PR is closed or a draft.
+            2. Run `git log --oneline ${{ github.event.before }}..${{ github.event.after }}`. If that fails (force push), review the whole PR with `gh pr diff ${{ github.event.pull_request.number }}` instead.
+            3. Ignore merge commits from the base branch and the changes they bring in. Review only commits the author wrote.
+            4. Read the diff of those commits with `git diff ${{ github.event.before }} ${{ github.event.after }}`, and read the root CLAUDE.md and AGENTS.md for repository rules.
+            5. Look for bugs, rule violations from CLAUDE.md or AGENTS.md, and regressions in the changed code. Skip nitpicks and pre-existing issues.
+            6. If you find no real issues, stop. Do not post a comment.
+            7. Otherwise post one comment with `gh pr comment`. Keep it brief, no emojis. Link each issue to the code with a full SHA and line range, for example `https://github.com/${{ github.repository }}/blob/${{ github.event.after }}/path/file.ts#L10-L12`.
+          claude_args: |
+            --model claude-opus-5
+            --max-turns 100
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),Bash(git show:*)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Cross-seed: a **Cross-seed in qui** context-menu item for `.torrent` links (#11). It lists every enabled instance and opens a picker window with the torrents qui ranks by file overlap. Pick a target from the ranked list or search the instance by name for any other torrent, set category and tags, and qui adds the torrent pinned to that target with a full recheck. Needs qui 1.28.0 or newer. Magnet links are rejected because they carry no file list.
 
 ### Changed
+- CI: the Claude review job reviews the whole PR when it opens and only the new commits on later pushes.
 - CI: the Claude review workflow uses Opus 5 with a 100-turn limit and runs only on PRs from the repository owner.
 - CI: the Claude review workflow can post its review comment. It ran on every PR but was denied write access and the `gh pr comment` tool, so it never posted.
 - CI runs `bun test` before the build. Dependabot checks GitHub Actions and bun dependencies weekly.


### PR DESCRIPTION
Keeps the code-review plugin for the first open of a PR. On later pushes, a custom prompt reviews only the commits between the previous and new head, and ignores merges from the base branch.

## How has this been tested?

The action skips runs where the workflow file differs from `main`, so the first real run is on the next owner PR push after merge.