### PR TITLE
fix: attach release zips and add a store submit script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/download-artifact@v8
+        with:
+          name: extensions
+          path: extensions
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules/
 .wxt/
 *.log
 .DS_Store
-.DS_Store
+.env.submit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ bun run build           # Production build (Chrome)
 bun run build:firefox   # Production build (Firefox)
 bun run zip             # Package for Chrome Web Store
 bun run zip:firefox     # Package for Firefox
+bun run submit          # Build and upload to both stores; needs .env.submit
 ```
 
 `bun test` runs the unit tests in `test/`. No lint command is configured.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ bun run submit          # Build and upload to both stores; needs .env.submit
 
 `bun test` runs the unit tests in `test/`. No lint command is configured.
 
+### WXT
+
+`postinstall` runs `wxt prepare`, which writes the generated types and the base `tsconfig.json` to `.wxt/`. `bun run typecheck` needs them. `wxt.config.ts` holds the manifest; the version comes from `package.json`. Builds land in `.output/chrome-mv3` and `.output/firefox-mv3`.
+
 ## Workflow
 
 - Update CHANGELOG.md for every commit.
@@ -74,3 +78,7 @@ The five canonical labels, unchanged: `needs-triage`, `needs-info`, `ready-for-a
 ### Domain docs
 
 Single-context: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Release
+
+Version bump, tag, store upload with `bun run submit`, the `.env.submit` layout, and store error meanings: see `docs/agents/release.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Release: `bun run submit` builds the zips and uploads them to the Chrome Web Store and Firefox Add-ons through `wxt submit`. Store credentials live in `.env.submit`, which git ignores. Run `bunx wxt submit init` once to create it.
+
+### Fixed
+- CI: the release job downloads the build artifact into `extensions/` again, so tagged builds attach the zips to the GitHub release.
+
 ## 0.4.0 — 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 ### Changed
-- Release: `bun run submit` builds the zips and uploads them to the Chrome Web Store and Firefox Add-ons through `wxt submit`. Store credentials live in `.env.submit`, which git ignores. Run `bunx wxt submit init` once to create it.
+- Release: `bun run submit` builds the zips and uploads them to the Chrome Web Store and Firefox Add-ons through `wxt submit`. Store credentials live in `.env.submit`, which git ignores. `docs/agents/release.md` has the layout.
+
+### Docs
+- Add `docs/agents/release.md` with the release steps, the `.env.submit` layout, and store error meanings.
 
 ### Fixed
 - CI: the release job downloads the build artifact into `extensions/` again, so tagged builds attach the zips to the GitHub release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Changed
-- Release: `bun run submit` builds the zips and uploads them to the Chrome Web Store and Firefox Add-ons through `wxt submit`. Store credentials live in `.env.submit`, which git ignores. `docs/agents/release.md` has the layout.
+- Release: `bun run submit` builds the zips and uploads them to the Chrome Web Store and Firefox Add-ons through `wxt submit`. Store credentials live in `.env.submit`, which git ignores. `docs/agents/release.md` has the layout. The Firefox version gets the CHANGELOG section of the release as its release notes.
 
 ### Docs
 - Add `docs/agents/release.md` with the release steps, the `.env.submit` layout, and store error meanings.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ bun run build       # Production build
 bun run zip         # Package for Chrome Web Store
 bun run zip:firefox # Package for Firefox
 ```
+
+## Release
+
+1. Bump `version` in `package.json` and date the `Unreleased` section in `CHANGELOG.md`.
+2. Push a `v*` tag. CI builds the zips and attaches them to the GitHub release.
+3. Run `bun run submit`. It rebuilds the zips and uploads them to the Chrome Web Store and Firefox Add-ons. It reads store credentials from `.env.submit`. Run `bunx wxt submit init` once to create that file.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,4 @@ bun run zip:firefox # Package for Firefox
 
 ## Release
 
-1. Bump `version` in `package.json` and date the `Unreleased` section in `CHANGELOG.md`.
-2. Push a `v*` tag. CI builds the zips and attaches them to the GitHub release.
-3. Run `bun run submit`. It rebuilds the zips and uploads them to the Chrome Web Store and Firefox Add-ons. It reads store credentials from `.env.submit`. Run `bunx wxt submit init` once to create that file.
+See `docs/agents/release.md`.

--- a/docs/agents/release.md
+++ b/docs/agents/release.md
@@ -16,6 +16,8 @@
    ```
    Done when the output shows a green check for both `Chrome Web Store` and `Firefox Addon Store`.
 
+   `scripts/amo-metadata.ts` turns the CHANGELOG section of the current version into the Firefox release notes. The Chrome Web Store has no release notes field.
+
 ## `.env.submit`
 
 `wxt submit` is an alias for `publish-browser-extension`. It reads `.env.submit` in the repo root. Git ignores that file. `wxt submit init` fails with a `chrome.clientId` validation error before it asks a question, so write the file by hand:

--- a/docs/agents/release.md
+++ b/docs/agents/release.md
@@ -1,0 +1,41 @@
+# Release
+
+`bun run zip` and `bun run zip:firefox` write `qui-<version>-chrome.zip`, `qui-<version>-firefox.zip`, and `qui-<version>-sources.zip` to `.output/`.
+
+## Steps
+
+1. Date the `Unreleased` heading in `CHANGELOG.md` and set `version` in `package.json`. Commit as `chore: bump version to X.Y.Z` on `main`.
+2. Tag and push:
+   ```bash
+   git tag -s vX.Y.Z -m vX.Y.Z && git push origin vX.Y.Z
+   ```
+   CI builds the zips and attaches them to the GitHub release. Done when `gh release view vX.Y.Z --json assets` lists all three zips.
+3. Upload to the stores:
+   ```bash
+   bun run submit
+   ```
+   Done when the output shows a green check for both `Chrome Web Store` and `Firefox Addon Store`.
+
+## `.env.submit`
+
+`wxt submit` is an alias for `publish-browser-extension`. It reads `.env.submit` in the repo root. Git ignores that file. `wxt submit init` fails with a `chrome.clientId` validation error before it asks a question, so write the file by hand:
+
+```
+CHROME_API_VERSION=v2
+CHROME_EXTENSION_ID=kbjnjgihepmcoilegnghgpmijbecoili
+CHROME_PUBLISHER_ID=bcd35b14-3115-4018-9df4-797a980244ac
+CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL=<client_email from the service account JSON key>
+CHROME_SERVICE_ACCOUNT_PRIVATE_KEY="<private_key from the JSON key, one line, \n escapes>"
+FIREFOX_EXTENSION_ID=qui@s0up4200
+FIREFOX_JWT_ISSUER=user:<digits>:<digits>
+FIREFOX_JWT_SECRET=<secret>
+```
+
+Chrome uses API v2. The service account lives in a Google Cloud project with the Chrome Web Store API enabled, and its email is listed in the Developer Dashboard under Publisher, Settings, Service account. The publisher ID is on the same page.
+
+Firefox keys come from https://addons.mozilla.org/developers/addon/api/key/. Generating a new key replaces the old one, so update `.env.submit` at the same time.
+
+## Store errors
+
+- Chrome `INVALID_ITEM_METADATA` at "Submitting for review": the zip is uploaded as a draft, and the store listing is incomplete. Complete the listing in the Developer Dashboard (permission justifications, publisher address) and submit for review there.
+- Firefox `Unknown JWT iss (issuer)`: the issuer value is malformed. The format is `user:<digits>:<digits>`.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:firefox": "wxt build --browser firefox --mv3",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip --browser firefox --mv3",
+    "submit": "rm -f .output/*.zip && bun run zip && bun run zip:firefox && wxt submit --chrome-zip .output/*-chrome.zip --firefox-zip .output/*-firefox.zip --firefox-sources-zip .output/*-sources.zip",
     "typecheck": "tsc --noEmit",
     "postinstall": "wxt prepare"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:firefox": "wxt build --browser firefox --mv3",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip --browser firefox --mv3",
-    "submit": "rm -f .output/*.zip && bun run zip && bun run zip:firefox && wxt submit --chrome-zip .output/*-chrome.zip --firefox-zip .output/*-firefox.zip --firefox-sources-zip .output/*-sources.zip",
+    "submit": "rm -f .output/*.zip && bun run zip && bun run zip:firefox && bun scripts/amo-metadata.ts && wxt submit --chrome-zip .output/*-chrome.zip --firefox-zip .output/*-firefox.zip --firefox-sources-zip .output/*-sources.zip --firefox-amo-metadata-file .output/amo-metadata.json",
     "typecheck": "tsc --noEmit",
     "postinstall": "wxt prepare"
   },

--- a/scripts/amo-metadata.ts
+++ b/scripts/amo-metadata.ts
@@ -1,0 +1,14 @@
+// Writes the release notes for `wxt submit --firefox-amo-metadata-file`
+// from the CHANGELOG.md section of the current package.json version.
+import { version } from '../package.json';
+
+const changelog = await Bun.file('CHANGELOG.md').text();
+const section = changelog.split(/^## /m).find((s) => s.startsWith(`${version} `));
+if (!section) throw new Error(`CHANGELOG.md has no section for ${version}`);
+
+const notes = section
+  .slice(section.indexOf('\n'))
+  .replace(/^### (.*)$/gm, '$1:')
+  .trim();
+
+await Bun.write('.output/amo-metadata.json', JSON.stringify({ version: { release_notes: { 'en-US': notes } } }));


### PR DESCRIPTION
Fixes the release job so tagged builds attach the zips to the GitHub release again. The v0.4.0 release came out empty and got its assets by hand.

Adds `bun run submit`, which rebuilds the zips and uploads them to the Chrome Web Store and Firefox Add-ons through `wxt submit`. The Firefox version gets the CHANGELOG section of the release as its release notes. Store credentials live in `.env.submit`, which git ignores; `docs/agents/release.md` has the layout, since `wxt submit init` fails before it asks a question.

## How has this been tested?

Confirmed `.env.submit` is ignored with `git check-ignore`. Ran `bun scripts/amo-metadata.ts` and checked the JSON holds the 0.4.0 section. Uploaded 0.4.0 to both stores with the same `wxt submit` flags the script uses. The workflow fix is not exercised until the next tag.