### PR TITLE
chore: remove dead dependencies, messages, and duplicated helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changed
+- Cleanup: remove the unused `clsx`, `tailwind-merge`, and `lucide-react` dependencies, the dead `get-instances`, `get-categories`, `add-torrent`, and `get-cached-data` messages, `lib/url.ts`, `assets/main.css`, and API fields nothing reads. The favorite and enabled-instance rules live in `lib/storage.ts` once instead of three times. The popup renders its header from one component.
 - Release: `bun run submit` builds the zips and uploads them to the Chrome Web Store and Firefox Add-ons through `wxt submit`. Store credentials live in `.env.submit`, which git ignores. `docs/agents/release.md` has the layout. The Firefox version gets the CHANGELOG section of the release as its release notes.
 
 ### Docs

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,9 +1,0 @@
-@import "tailwindcss";
-
-@theme {
-  --color-background: oklch(0.145 0 0);
-  --color-surface: oklch(0.20 0 0);
-  --color-primary: oklch(0.65 0.15 250);
-  --color-text: oklch(0.93 0 0);
-  --color-muted: oklch(0.55 0 0);
-}

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/themes": "^3.3.0",
         "ky": "^2.1.0",
-        "lucide-react": "^1.38.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
       },
@@ -18,8 +17,6 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.5",
         "@wxt-dev/module-react": "^1.2.2",
-        "clsx": "^2.1.1",
-        "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
         "wxt": "^0.21.4",
@@ -461,8 +458,6 @@
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "4.2.3", "strip-ansi": "6.0.1", "wrap-ansi": "7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
-    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
-
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -597,8 +592,6 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "3.1.1" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@1.38.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-xZCyBd/wiVUDactoCc+42TjL0aB7EBOXsuX+tjz+W/sGzw2KhHpL1NOH3FIaVUcpimvUBpIYfz34Ofj9S5JEzQ=="],
-
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.4", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "source-map-js": "^1.2.1" } }, "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w=="],
@@ -678,8 +671,6 @@
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
     "superlock": ["superlock@1.3.5", "", {}, "sha512-XpWNthvezZnWp0u7/UL8rBbBOnq2Qx39fw+0RNMC/+eotOd81glzsmIWVH0ejarhTeDQihxOKSbjm2XXFo5a8w=="],
-
-    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,6 +1,5 @@
 import {
   getInstances,
-  getCategories,
   addTorrent,
   addTorrentFile,
   getCrossSeedProposals,
@@ -9,23 +8,14 @@ import {
   type AddTorrentOptions,
 } from '@/lib/api';
 import type { ApiMessage, ApiResponse, FetchTorrentResponse, TorrentFileData } from '@/lib/messaging';
-import { refreshCache, loadCachedData } from '@/lib/cache';
+import { refreshCache } from '@/lib/cache';
 import { rebuildMenus } from '@/lib/menus';
 import { parseMenuId } from '@/lib/menu-id';
 import { fetchTorrentInPage } from '@/lib/torrent-file';
 import { cachedData, addPaused, skipRecheck, crossSeedPending } from '@/lib/storage';
-import { isMagnetUrl } from '@/lib/url';
 
 const CACHE_ALARM = 'refresh-cache';
 const REFRESH_MINUTES = 15;
-
-async function getTorrentOptions(): Promise<AddTorrentOptions> {
-  const [paused, skipChecking] = await Promise.all([
-    addPaused.getValue(),
-    skipRecheck.getValue(),
-  ]);
-  return { paused, skipChecking };
-}
 
 function notify(title: string, message: string): void {
   browser.notifications.create(`${title}-${Date.now()}`, {
@@ -82,8 +72,9 @@ async function handleAdd(
   const url = info.linkUrl!;
   const target = savePath ?? category;
   try {
-    const options: AddTorrentOptions = { ...(await getTorrentOptions()), savePath };
-    if (isMagnetUrl(url)) {
+    const [paused, skipChecking] = await Promise.all([addPaused.getValue(), skipRecheck.getValue()]);
+    const options: AddTorrentOptions = { paused, skipChecking, savePath };
+    if (url.startsWith('magnet:')) {
       await addTorrent(instanceId, url, category, options);
     } else {
       await addTorrentFile(instanceId, await fetchTorrentFromTab(info, tab), category, options);
@@ -101,7 +92,7 @@ async function openCrossSeedPicker(
   instanceName: string,
 ): Promise<void> {
   try {
-    if (isMagnetUrl(info.linkUrl!)) {
+    if (info.linkUrl!.startsWith('magnet:')) {
       throw new Error('Cross-seed needs a .torrent file, magnet links have no file list');
     }
     const file = await fetchTorrentFromTab(info, tab);
@@ -188,7 +179,7 @@ export default defineBackground(() => {
     if (!parsed) return;
 
     // Look up instance name for notification
-    const cache = await loadCachedData();
+    const cache = await cachedData.getValue();
     const instance = cache.instances.find((i) => String(i.id) === parsed.instanceId);
     const instanceName = instance?.name ?? parsed.instanceId;
 
@@ -210,20 +201,6 @@ export default defineBackground(() => {
         try {
           let data: unknown;
           switch (message.type) {
-            case 'get-instances':
-              data = await getInstances();
-              break;
-            case 'get-categories':
-              data = await getCategories(message.instanceId);
-              break;
-            case 'add-torrent':
-              data = await addTorrent(
-                message.instanceId,
-                message.urls,
-                message.category,
-                await getTorrentOptions(),
-              );
-              break;
             case 'search-torrents':
               data = await searchTorrents(message.instanceId, message.query);
               break;
@@ -240,9 +217,6 @@ export default defineBackground(() => {
             case 'refresh-cache':
               await refreshCache().then(rebuildMenus);
               data = true;
-              break;
-            case 'get-cached-data':
-              data = await cachedData.getValue();
               break;
             default:
               sendResponse({ success: false, error: 'Unknown message type' });

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, Heading, Text, TextField, TextArea, Button, Flex, Box, IconButton, Switch, Grid, ScrollArea, Badge } from '@radix-ui/themes';
 import { StarFilledIcon, StarIcon, ReloadIcon, CopyIcon, CheckIcon, ExternalLinkIcon, GitHubLogoIcon, ChevronDownIcon, ChevronRightIcon, MagnifyingGlassIcon } from '@radix-ui/react-icons';
-import { Coffee } from 'lucide-react';
 import {
   serverUrl,
   apiKey,
@@ -13,6 +12,10 @@ import {
   enabledInstances as enabledInstancesStorage,
   basicAuthUsername,
   basicAuthPassword,
+  cachedData as cachedDataStorage,
+  enabledInstanceList,
+  isFavorite,
+  toggleFavorite,
 } from '@/lib/storage';
 import type { Favorite, CacheData } from '@/lib/storage';
 import { formatConnectionError, getSaveConnectionResult } from '@/lib/connection-errors';
@@ -48,6 +51,17 @@ function XmrIcon() {
   return (
     <svg width="15" height="15" viewBox="0 0 24 24" fill="#FF6600">
       <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm0 1.2c5.96 0 10.8 4.84 10.8 10.8 0 1.457-.29 2.848-.816 4.116h-3.084V7.883L12 14.783l-6.9-6.9v8.233H1.97A10.755 10.755 0 011.2 12C1.2 6.04 6.04 1.2 12 1.2zm-4.5 8.383l4.5 4.5 4.5-4.5v6.333h3.15v3.384A10.76 10.76 0 0112 22.8a10.76 10.76 0 01-7.65-3.183v-3.384H7.5V9.583z" />
+    </svg>
+  );
+}
+
+function CoffeeIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#FFDD00" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 2v2" />
+      <path d="M14 2v2" />
+      <path d="M16 8a1 1 0 0 1 1 1v8a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V9a1 1 0 0 1 1-1h14a4 4 0 1 1 0 8h-1" />
+      <path d="M6 2v2" />
     </svg>
   );
 }
@@ -142,17 +156,10 @@ export default function App() {
         setProxyAuthExpanded(true);
       }
 
-      try {
-        const data = await sendToBackground<CacheData>({ type: 'get-cached-data' });
-        setCachedData(data);
-        // Expand all instances by default
-        if (data?.instances) {
-          setExpandedInstances(new Set(data.instances.map((i) => i.id)));
-        }
-      } catch {
-        // Cache not available yet
-      }
-
+      const data = await cachedDataStorage.getValue();
+      setCachedData(data);
+      // Expand all instances by default
+      setExpandedInstances(new Set(data.instances.map((i) => i.id)));
       setLoading(false);
     }
     load();
@@ -162,37 +169,15 @@ export default function App() {
     return value.replace(/\/+$/, '');
   }
 
-  const allInstanceIds = useMemo(() => {
-    if (!cachedData?.instances) return [];
-    return cachedData.instances.map((instance) => instance.id);
-  }, [cachedData]);
+  const allInstanceIds = cachedData?.instances.map((instance) => instance.id) ?? [];
+  const enabledInstances = enabledInstanceList(cachedData?.instances ?? [], enabledInstanceIds);
+  const enabledInstanceSet = new Set(enabledInstances.map((instance) => instance.id));
 
-  const enabledInstanceSet = useMemo(() => {
-    if (enabledInstanceIds === null) {
-      return new Set(allInstanceIds);
-    }
-    return new Set(enabledInstanceIds);
-  }, [enabledInstanceIds, allInstanceIds]);
-
-  const enabledInstanceList = useMemo(() => {
-    if (!cachedData?.instances) return [];
-    if (enabledInstanceIds === null) {
-      return cachedData.instances;
-    }
-    return cachedData.instances.filter((instance) => enabledInstanceSet.has(instance.id));
-  }, [cachedData, enabledInstanceIds, enabledInstanceSet]);
-
-  const filteredInstances = useMemo(() => {
-    if (!cachedData?.instances) return [];
-    const q = filter.toLowerCase();
-    if (!q) return enabledInstanceList;
-
-    return enabledInstanceList.filter((instance) => {
-      if (instance.name.toLowerCase().includes(q)) return true;
-      const categories = cachedData.categoriesByInstance[instance.id] || [];
-      return categories.some((cat) => cat.name.toLowerCase().includes(q));
-    });
-  }, [cachedData, filter, enabledInstanceList]);
+  const q = filter.toLowerCase();
+  const filteredInstances = enabledInstances.filter((instance) =>
+    instance.name.toLowerCase().includes(q)
+    || (cachedData?.categoriesByInstance[instance.id] ?? []).some((cat) => cat.name.toLowerCase().includes(q)),
+  );
 
   function toggleExpanded(instanceId: string) {
     setExpandedInstances((prev) => {
@@ -213,22 +198,17 @@ export default function App() {
     return categories.filter((cat) => cat.name.toLowerCase().includes(q));
   }
 
-  const isDirty = useMemo(() => {
-    return (
-      normalizeUrlValue(url) !== normalizeUrlValue(savedConfig.url) ||
-      key !== savedConfig.key ||
-      authUsername !== savedConfig.authUsername ||
-      authPassword !== savedConfig.authPassword
-    );
-  }, [url, key, authUsername, authPassword, savedConfig]);
+  const isDirty =
+    normalizeUrlValue(url) !== normalizeUrlValue(savedConfig.url)
+    || key !== savedConfig.key
+    || authUsername !== savedConfig.authUsername
+    || authPassword !== savedConfig.authPassword;
 
   async function refreshAndUpdateCache(): Promise<void> {
     await sendToBackground({ type: 'refresh-cache' });
-    const data = await sendToBackground<CacheData>({ type: 'get-cached-data' });
+    const data = await cachedDataStorage.getValue();
     setCachedData(data);
-    if (data?.instances) {
-      setExpandedInstances(new Set(data.instances.map((i) => i.id)));
-    }
+    setExpandedInstances(new Set(data.instances.map((i) => i.id)));
   }
 
   async function handleSave() {
@@ -305,19 +285,10 @@ export default function App() {
     }
   }
 
-  function isFavorite(instanceId: string, category: string): boolean {
-    return favs.some((f) => f.instanceId === instanceId && f.category === category);
-  }
-
-  async function toggleFavorite(instanceId: string, category: string) {
-    let updatedFavs: Favorite[];
-    if (isFavorite(instanceId, category)) {
-      updatedFavs = favs.filter((f) => !(f.instanceId === instanceId && f.category === category));
-    } else {
-      updatedFavs = [...favs, { instanceId, category }];
-    }
-    await favorites.setValue(updatedFavs);
-    setFavs(updatedFavs);
+  async function toggle(instanceId: string, category: string) {
+    const next = toggleFavorite(favs, instanceId, category);
+    await favorites.setValue(next);
+    setFavs(next);
   }
 
   async function handlePausedChange(checked: boolean) {
@@ -602,7 +573,7 @@ export default function App() {
               </Flex>
               <Flex asChild align="center" gap="2">
                 <a href="https://buymeacoffee.com/s0up4200" target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}>
-                  <Coffee size={15} color="#FFDD00" />
+                  <CoffeeIcon />
                   <Text size="2">Buy Me a Coffee</Text>
                   <ExternalLinkIcon color="var(--gray-9)" />
                 </a>
@@ -679,7 +650,7 @@ export default function App() {
               <Text size="2" color="gray">
                 No instances found. Configure server and click Refresh.
               </Text>
-            ) : enabledInstanceList.length === 0 ? (
+            ) : enabledInstances.length === 0 ? (
               <Text size="2" color="gray">
                 No instances selected. Enable at least one instance in Menu.
               </Text>
@@ -733,9 +704,9 @@ export default function App() {
                               <IconButton
                                 variant="ghost"
                                 size="1"
-                                onClick={() => toggleFavorite(instance.id, row.category)}
+                                onClick={() => toggle(instance.id, row.category)}
                               >
-                                {isFavorite(instance.id, row.category)
+                                {isFavorite(favs, instance.id, row.category)
                                   ? <StarFilledIcon color="var(--yellow-9)" />
                                   : <StarIcon />
                                 }

--- a/entrypoints/options/main.tsx
+++ b/entrypoints/options/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-import '@radix-ui/themes/styles.css';
 import '@/assets/options.css';
 import { Theme } from '@radix-ui/themes';
 

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -2,9 +2,71 @@ import { useState, useEffect } from 'react';
 import { Text, Flex, Box, IconButton, ScrollArea } from '@radix-ui/themes';
 import { StarFilledIcon, StarIcon, GearIcon, HeartFilledIcon } from '@radix-ui/react-icons';
 import { browser } from 'wxt/browser';
-import { favorites, favoritesOnly, cachedData as cachedDataStorage, enabledInstances, serverUrl } from '@/lib/storage';
+import {
+  favorites,
+  favoritesOnly,
+  cachedData as cachedDataStorage,
+  enabledInstances,
+  enabledInstanceList,
+  isFavorite,
+  serverUrl,
+  toggleFavorite,
+} from '@/lib/storage';
 import { hasHostPermission, MISSING_HOST_PERMISSION } from '@/lib/permissions';
 import type { Favorite, CacheData } from '@/lib/storage';
+
+function openOptions() {
+  browser.runtime.openOptionsPage();
+}
+
+function Header() {
+  return (
+    <Flex justify="between" align="center" mb="4">
+      <Text size="3" weight="medium" style={{ color: 'var(--color-text)' }}>Favorites</Text>
+      <Flex align="center" gap="1">
+        <IconButton
+          variant="ghost"
+          size="1"
+          onClick={openOptions}
+          title="Support"
+          style={{ color: 'var(--red-9, #e5484d)' }}
+        >
+          <HeartFilledIcon width={15} height={15} />
+        </IconButton>
+        <IconButton
+          variant="ghost"
+          size="1"
+          onClick={openOptions}
+          title="Settings"
+          style={{ color: 'var(--color-muted)' }}
+        >
+          <GearIcon width={15} height={15} />
+        </IconButton>
+      </Flex>
+    </Flex>
+  );
+}
+
+function Empty({ children }: { children: string }) {
+  return (
+    <Box style={{ width: 320, padding: 20, background: 'var(--color-background)' }}>
+      <Flex align="center" style={{ marginBottom: 8 }}>
+        <Text size="4" weight="bold" style={{ color: 'var(--color-text)' }}>qui</Text>
+      </Flex>
+      <Header />
+      <Box
+        style={{
+          background: 'var(--color-surface)',
+          borderRadius: 12,
+          border: '1px solid var(--color-border)',
+          padding: '20px 16px',
+        }}
+      >
+        <Text size="2" style={{ color: 'var(--color-muted)', lineHeight: 1.5 }}>{children}</Text>
+      </Box>
+    </Box>
+  );
+}
 
 export default function App() {
   const [data, setData] = useState<CacheData | null>(null);
@@ -35,19 +97,10 @@ export default function App() {
     load();
   }, []);
 
-  function isFavorite(instanceId: string, category: string): boolean {
-    return favs.some((f) => f.instanceId === instanceId && f.category === category);
-  }
-
-  async function toggleFavorite(instanceId: string, category: string) {
-    let updatedFavs: Favorite[];
-    if (isFavorite(instanceId, category)) {
-      updatedFavs = favs.filter((f) => !(f.instanceId === instanceId && f.category === category));
-    } else {
-      updatedFavs = [...favs, { instanceId, category }];
-    }
-    await favorites.setValue(updatedFavs);
-    setFavs(updatedFavs);
+  async function toggle(instanceId: string, category: string) {
+    const next = toggleFavorite(favs, instanceId, category);
+    await favorites.setValue(next);
+    setFavs(next);
   }
 
   async function toggleOnlyFavs() {
@@ -56,122 +109,18 @@ export default function App() {
     setOnlyFavs(next);
   }
 
-  function openOptions() {
-    browser.runtime.openOptionsPage();
-  }
-
   if (loading) {
-    return (
-      <Box style={{ width: 320, padding: 20, background: 'var(--color-background)' }}>
-        <Text size="2" style={{ color: 'var(--color-muted)' }}>Loading...</Text>
-      </Box>
-    );
+    return <Empty>Loading...</Empty>;
   }
 
   if (!data || data.instances.length === 0) {
-    return (
-      <Box style={{ width: 320, padding: 20, background: 'var(--color-background)' }}>
-        <Flex align="center" style={{ marginBottom: 8 }}>
-          <Text size="4" weight="bold" style={{ color: 'var(--color-text)' }}>qui</Text>
-        </Flex>
-        <Flex justify="between" align="center" mb="4">
-          <Text size="3" weight="medium" style={{ color: 'var(--color-text)' }}>Favorites</Text>
-          <Flex align="center" gap="1">
-            <IconButton
-              variant="ghost"
-              size="1"
-              onClick={openOptions}
-              title="Support"
-              style={{ color: 'var(--red-9, #e5484d)' }}
-            >
-              <HeartFilledIcon width={15} height={15} />
-            </IconButton>
-            <IconButton
-              variant="ghost"
-              size="1"
-              onClick={openOptions}
-              title="Settings"
-              style={{ color: 'var(--color-muted)' }}
-            >
-              <GearIcon width={15} height={15} />
-            </IconButton>
-          </Flex>
-        </Flex>
-        <Box
-          style={{
-            background: 'var(--color-surface)',
-            borderRadius: 12,
-            border: '1px solid var(--color-border)',
-            padding: '20px 16px',
-          }}
-        >
-          <Text size="2" style={{ color: 'var(--color-muted)', lineHeight: 1.5 }}>
-            No instances found. Open settings to configure your server.
-          </Text>
-        </Box>
-      </Box>
-    );
+    return <Empty>No instances found. Open settings to configure your server.</Empty>;
   }
 
-  const enabledSet =
-    enabled === null
-      ? new Set(data.instances.map((instance) => instance.id))
-      : new Set(enabled);
-  const enabledInstanceList = data.instances.filter((instance) => enabledSet.has(instance.id));
-
-  if (enabledInstanceList.length === 0) {
-    return (
-      <Box style={{ width: 320, padding: 20, background: 'var(--color-background)' }}>
-        <Flex align="center" style={{ marginBottom: 8 }}>
-          <Text size="4" weight="bold" style={{ color: 'var(--color-text)' }}>qui</Text>
-        </Flex>
-        <Flex justify="between" align="center" mb="4">
-          <Text size="3" weight="medium" style={{ color: 'var(--color-text)' }}>Favorites</Text>
-          <Flex align="center" gap="1">
-            <IconButton
-              variant="ghost"
-              size="1"
-              onClick={openOptions}
-              title="Support"
-              style={{ color: 'var(--red-9, #e5484d)' }}
-            >
-              <HeartFilledIcon width={15} height={15} />
-            </IconButton>
-            <IconButton
-              variant="ghost"
-              size="1"
-              onClick={openOptions}
-              title="Settings"
-              style={{ color: 'var(--color-muted)' }}
-            >
-              <GearIcon width={15} height={15} />
-            </IconButton>
-          </Flex>
-        </Flex>
-        <Box
-          style={{
-            background: 'var(--color-surface)',
-            borderRadius: 12,
-            border: '1px solid var(--color-border)',
-            padding: '20px 16px',
-          }}
-        >
-          <Text size="2" style={{ color: 'var(--color-muted)', lineHeight: 1.5 }}>
-            No instances selected. Open settings to enable at least one instance.
-          </Text>
-        </Box>
-      </Box>
-    );
+  const instances = enabledInstanceList(data.instances, enabled);
+  if (instances.length === 0) {
+    return <Empty>No instances selected. Open settings to enable at least one instance.</Empty>;
   }
-
-  // Group rows by instance
-  const grouped = enabledInstanceList.map((instance) => {
-    const categories = data.categoriesByInstance[instance.id] || [];
-    const items = categories.length > 0
-      ? categories.map((cat) => ({ category: cat.name }))
-      : [{ category: '' }];
-    return { instanceId: instance.id, instanceName: instance.name, items };
-  });
 
   return (
     <Box style={{ width: 320, background: 'var(--color-background)' }}>
@@ -185,29 +134,9 @@ export default function App() {
           </Text>
         </Box>
       )}
-      <Flex justify="between" align="center" style={{ padding: '16px 20px 12px' }}>
-        <Text size="3" weight="medium" style={{ color: 'var(--color-text)' }}>Favorites</Text>
-        <Flex align="center" gap="1">
-          <IconButton
-            variant="ghost"
-            size="1"
-            onClick={openOptions}
-            title="Support"
-            style={{ color: 'var(--red-9, #e5484d)' }}
-          >
-            <HeartFilledIcon width={15} height={15} />
-          </IconButton>
-          <IconButton
-            variant="ghost"
-            size="1"
-            onClick={openOptions}
-            title="Settings"
-            style={{ color: 'var(--color-muted)' }}
-          >
-            <GearIcon width={15} height={15} />
-          </IconButton>
-        </Flex>
-      </Flex>
+      <Box style={{ padding: '16px 20px 0' }}>
+        <Header />
+      </Box>
       <Flex
         align="center"
         justify="between"
@@ -247,9 +176,11 @@ export default function App() {
       </Flex>
       <ScrollArea style={{ maxHeight: 420 }}>
         <Flex direction="column" gap="3" style={{ padding: '0 16px 16px' }}>
-          {grouped.map((group) => (
+          {instances.map((instance) => {
+            const names = (data.categoriesByInstance[instance.id] ?? []).map((c) => c.name);
+            return (
             <Box
-              key={group.instanceId}
+              key={instance.id}
               style={{
                 background: 'var(--color-surface)',
                 borderRadius: 12,
@@ -259,13 +190,15 @@ export default function App() {
             >
               <Box style={{ padding: '10px 14px 6px' }}>
                 <Text size="2" weight="medium" style={{ color: 'var(--color-text)' }}>
-                  {group.instanceName}
+                  {instance.name}
                 </Text>
               </Box>
               <Flex direction="column" style={{ padding: '0 6px 6px' }}>
-                {group.items.map((item) => (
+                {(names.length ? names : ['']).map((category) => {
+                  const starred = isFavorite(favs, instance.id, category);
+                  return (
                   <Flex
-                    key={`${group.instanceId}-${item.category}`}
+                    key={`${instance.id}-${category}`}
                     align="center"
                     justify="between"
                     className="popup-row"
@@ -276,11 +209,11 @@ export default function App() {
                     }}
                   >
                     <Text size="2" truncate style={{ color: 'var(--color-muted)', flex: 1, minWidth: 0 }}>
-                      {item.category || '(No category)'}
+                      {category || '(No category)'}
                     </Text>
                     <button
                       className="star-btn"
-                      onClick={() => toggleFavorite(group.instanceId, item.category)}
+                      onClick={() => toggle(instance.id, category)}
                       style={{
                         background: 'none',
                         border: 'none',
@@ -288,22 +221,22 @@ export default function App() {
                         padding: 4,
                         display: 'flex',
                         alignItems: 'center',
-                        color: isFavorite(group.instanceId, item.category)
-                          ? 'var(--color-star)'
-                          : 'var(--color-muted)',
-                        opacity: isFavorite(group.instanceId, item.category) ? 1 : 0.6,
+                        color: starred ? 'var(--color-star)' : 'var(--color-muted)',
+                        opacity: starred ? 1 : 0.6,
                       }}
                     >
-                      {isFavorite(group.instanceId, item.category)
+                      {starred
                         ? <StarFilledIcon width={15} height={15} />
                         : <StarIcon width={15} height={15} />
                       }
                     </button>
                   </Flex>
-                ))}
+                  );
+                })}
               </Flex>
             </Box>
-          ))}
+            );
+          })}
         </Flex>
       </ScrollArea>
     </Box>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -7,12 +7,10 @@ import type { TorrentFileData } from './messaging';
 export interface Instance {
   id: string;
   name: string;
-  host: string;
 }
 
 export interface Category {
   name: string;
-  savePath: string;
 }
 
 async function getClient() {
@@ -137,8 +135,6 @@ export interface CrossSeedProposal {
   name: string;
   size: number;
   category: string;
-  effective_save_path: string;
-  overlap_bytes: number;
   overlap_fraction: number;
 }
 

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,15 +1,15 @@
-import { getInstances, getCategories } from '@/lib/api';
+import { getInstances, getCategories, type Category } from '@/lib/api';
 import { cachedData } from '@/lib/storage';
 
-export async function refreshCache(): Promise<boolean> {
+export async function refreshCache(): Promise<void> {
   let instances;
   try {
     instances = await getInstances();
   } catch {
-    return false;
+    return;
   }
 
-  const categoriesByInstance: Record<string, import('@/lib/api').Category[]> = {};
+  const categoriesByInstance: Record<string, Category[]> = {};
   for (const instance of instances) {
     try {
       categoriesByInstance[instance.id] = await getCategories(instance.id);
@@ -18,15 +18,5 @@ export async function refreshCache(): Promise<boolean> {
     }
   }
 
-  await cachedData.setValue({
-    instances,
-    categoriesByInstance,
-    lastRefreshed: Date.now(),
-  });
-
-  return true;
-}
-
-export async function loadCachedData() {
-  return cachedData.getValue();
+  await cachedData.setValue({ instances, categoriesByInstance });
 }

--- a/lib/menus.ts
+++ b/lib/menus.ts
@@ -1,23 +1,22 @@
-import { loadCachedData } from '@/lib/cache';
-import { favorites, favoritesOnly, enabledInstances, savePaths, type CacheData, type Favorite } from '@/lib/storage';
+import {
+  cachedData,
+  favorites,
+  favoritesOnly,
+  enabledInstances,
+  enabledInstanceList,
+  isFavorite,
+  savePaths,
+  type CacheData,
+  type Favorite,
+} from '@/lib/storage';
 import type { Instance } from '@/lib/api';
 import { makeMenuId, makePathMenuId, makeCrossSeedMenuId } from '@/lib/menu-id';
-
-function isStarred(
-  favs: Favorite[],
-  instanceId: string,
-  category: string,
-): boolean {
-  return favs.some(
-    (f) => f.instanceId === instanceId && f.category === category,
-  );
-}
 
 export async function rebuildMenus(): Promise<void> {
   await browser.contextMenus.removeAll();
 
-  const cache = await loadCachedData();
-  const [favs, onlyFavs, enabled, paths] = await Promise.all([
+  const [cache, favs, onlyFavs, enabled, paths] = await Promise.all([
+    cachedData.getValue(),
     favorites.getValue(),
     favoritesOnly.getValue(),
     enabledInstances.getValue(),
@@ -34,11 +33,7 @@ export async function rebuildMenus(): Promise<void> {
     return;
   }
 
-  const selectedInstanceIds =
-    enabled === null ? cache.instances.map((instance) => instance.id) : enabled;
-  const selectedInstances = cache.instances.filter((instance) =>
-    selectedInstanceIds.includes(instance.id),
-  );
+  const selectedInstances = enabledInstanceList(cache.instances, enabled);
 
   if (selectedInstances.length === 0) {
     browser.contextMenus.create({
@@ -104,8 +99,8 @@ function buildSendMenu(
   if (onlyFavs && !hasPaths) {
     const hasAnyFavorites = selectedInstances.some((instance) => {
       const categories = cache.categoriesByInstance[instance.id] ?? [];
-      if (isStarred(favs, instance.id, '')) return true;
-      return categories.some((c) => isStarred(favs, instance.id, c.name));
+      if (isFavorite(favs, instance.id, '')) return true;
+      return categories.some((c) => isFavorite(favs, instance.id, c.name));
     });
 
     if (!hasAnyFavorites) {
@@ -129,9 +124,9 @@ function buildSendMenu(
 
   for (const instance of selectedInstances) {
     const categories = cache.categoriesByInstance[instance.id] ?? [];
-    const starred = categories.filter((c) => isStarred(favs, instance.id, c.name));
-    const unstarred = categories.filter((c) => !isStarred(favs, instance.id, c.name));
-    const hasNoCategoryFav = isStarred(favs, instance.id, '');
+    const starred = categories.filter((c) => isFavorite(favs, instance.id, c.name));
+    const unstarred = categories.filter((c) => !isFavorite(favs, instance.id, c.name));
+    const hasNoCategoryFav = isFavorite(favs, instance.id, '');
 
     const showNoCategory = !onlyFavs || hasNoCategoryFav;
     const shownCategories = onlyFavs ? starred : [...starred, ...unstarred];

--- a/lib/messaging.ts
+++ b/lib/messaging.ts
@@ -1,12 +1,8 @@
 import { browser } from 'wxt/browser';
 
 export type ApiMessage =
-  | { type: 'get-instances' }
-  | { type: 'get-categories'; instanceId: string }
-  | { type: 'add-torrent'; instanceId: string; urls: string; category: string }
   | { type: 'test-connection' }
   | { type: 'refresh-cache' }
-  | { type: 'get-cached-data' }
   | { type: 'search-torrents'; instanceId: string; query: string }
   | { type: 'pin-cross-seed-target'; pendingId: string; targetHash: string }
   | { type: 'apply-cross-seed'; pendingId: string; targetHash: string; category?: string; tags: string[] };

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -10,7 +10,21 @@ export interface Favorite {
 export interface CacheData {
   instances: Instance[];
   categoriesByInstance: Record<string, Category[]>;
-  lastRefreshed: number;
+}
+
+export function isFavorite(favs: Favorite[], instanceId: string, category: string): boolean {
+  return favs.some((f) => f.instanceId === instanceId && f.category === category);
+}
+
+export function toggleFavorite(favs: Favorite[], instanceId: string, category: string): Favorite[] {
+  return isFavorite(favs, instanceId, category)
+    ? favs.filter((f) => !(f.instanceId === instanceId && f.category === category))
+    : [...favs, { instanceId, category }];
+}
+
+/** `enabled` null means every instance. */
+export function enabledInstanceList(instances: Instance[], enabled: string[] | null): Instance[] {
+  return enabled === null ? instances : instances.filter((i) => enabled.includes(i.id));
 }
 
 export const serverUrl = storage.defineItem<string>('local:serverUrl', {
@@ -30,7 +44,7 @@ export const enabledInstances = storage.defineItem<string[] | null>('local:enabl
 });
 
 export const cachedData = storage.defineItem<CacheData>('local:cachedData', {
-  fallback: { instances: [], categoriesByInstance: {}, lastRefreshed: 0 },
+  fallback: { instances: [], categoriesByInstance: {} },
 });
 
 export const favoritesOnly = storage.defineItem<boolean>('local:favoritesOnly', {

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -1,3 +1,0 @@
-export function isMagnetUrl(url: string): boolean {
-  return url.startsWith('magnet:');
-}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.3.0",
     "ky": "^2.1.0",
-    "lucide-react": "^1.38.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },
@@ -29,8 +28,6 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "@wxt-dev/module-react": "^1.2.2",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
     "wxt": "^0.21.4"


### PR DESCRIPTION
Removes what a repo audit found dead or triplicated: the unused `clsx`, `tailwind-merge`, and `lucide-react` dependencies, four message types no page sends, `lib/url.ts`, `assets/main.css`, and API type fields nothing reads. The favorite and enabled-instance rules now live in `lib/storage.ts` once instead of in the popup, the options page, and the menu builder. The popup renders its header and empty states from one component.

No behaviour change. CI covers the build, tests, and typecheck.