### PR TITLE
fix: encode fetched torrents with FileReader so Firefox can add them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `docs/agents/release.md` with the release steps, the `.env.submit` layout, and store error meanings.
 
 ### Fixed
+- Firefox: adding a `.torrent` link failed with "Fetch failed" since 0.4.0. The in-tab download succeeded, but Firefox blocks typed-array methods on the response bytes across its realm boundary, and the error text was lost. The encode now uses `FileReader`, and the notification shows the real Firefox error when a fetch fails.
 - CI: the release job downloads the build artifact into `extensions/` again, so tagged builds attach the zips to the GitHub release.
 
 ## 0.4.0 — 2026-09-03

--- a/lib/torrent-file.ts
+++ b/lib/torrent-file.ts
@@ -18,23 +18,27 @@ export async function fetchTorrentInPage(url: string): Promise<FetchTorrentRespo
       return { success: false, error: `HTTP ${response.status}` };
     }
 
-    // ponytail: chunked to stay linear and under the fromCharCode arg limit —
-    // an unchunked encode is what locks up on large files.
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    const chunks: string[] = [];
-    for (let i = 0; i < bytes.length; i += 0x8000) {
-      chunks.push(String.fromCharCode(...bytes.subarray(i, i + 0x8000)));
-    }
+    // FileReader does the base64 encode natively. Firefox hands the
+    // response bytes across a realm boundary, and typed-array methods on
+    // them fail with "Permission denied to access property constructor".
+    const dataUrl = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(reader.error);
+      response.blob().then((blob) => reader.readAsDataURL(blob), reject);
+    });
 
     return {
       success: true,
       data: {
-        base64: btoa(chunks.join('')),
+        base64: dataUrl.slice(dataUrl.indexOf(',') + 1),
         contentType: response.headers.get('content-type') || 'application/x-bittorrent',
       },
     };
   } catch (e) {
-    return { success: false, error: e instanceof Error ? e.message : 'Fetch failed' };
+    // Firefox hands the page's TypeError across a realm boundary, so
+    // `instanceof Error` is false there. String(e) keeps the real message.
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
   }
 }
 

--- a/test/torrent-file.test.ts
+++ b/test/torrent-file.test.ts
@@ -3,6 +3,19 @@ import { blobFromTorrentFile, fetchTorrentInPage } from '../lib/torrent-file';
 
 const realFetch = globalThis.fetch;
 
+// Bun has no FileReader. The shim covers readAsDataURL only.
+class FileReaderShim {
+  result: string | null = null;
+  onload: (() => void) | null = null;
+  readAsDataURL(blob: Blob) {
+    blob.arrayBuffer().then((buf) => {
+      this.result = `data:${blob.type};base64,${Buffer.from(buf).toString('base64')}`;
+      this.onload?.();
+    });
+  }
+}
+(globalThis as { FileReader?: unknown }).FileReader ??= FileReaderShim;
+
 afterEach(() => {
   globalThis.fetch = realFetch;
 });


### PR DESCRIPTION
Fixes the Firefox add-on failing on every `.torrent` link since 0.4.0 with "Failed to Add Torrent / Fetch failed". The in-tab download succeeded, but the base64 encode ran typed-array methods on bytes that cross a realm boundary inside the function injected by `scripting.executeScript`, and Firefox threw `Permission denied to access property "constructor"`. The old fallback hid that text. The encode now uses `FileReader.readAsDataURL`, which 0.3.0 used, and a fetch failure now reports the real error.

## How has this been tested?

Ran the dev build as a temporary add-on in Firefox 154 and as an unpacked extension in Chrome against a local two-port rig: a cookie-gated tracker page on `localhost` and a qui stub on `127.0.0.1` that logs the multipart body. Before the change Firefox showed the constructor error. After it, both browsers delivered the torrent bytes intact to the stub. A cross-origin download link fails in both browsers with a network error, which is the MV3 page-CORS rule and unchanged by this PR.