### PR TITLE
fix: remove extra context menu level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Menu: group cross-seed, categories, and saved paths under one "qui" menu (#31). One enabled instance needs no instance submenu. Favorites only filters categories.
+
 ## 0.4.1 — 2026-09-04
 
 ### Changed

--- a/lib/menus.ts
+++ b/lib/menus.ts
@@ -1,6 +1,5 @@
 import { loadCachedData } from '@/lib/cache';
-import { favorites, favoritesOnly, enabledInstances, savePaths, type CacheData, type Favorite } from '@/lib/storage';
-import type { Instance } from '@/lib/api';
+import { favorites, favoritesOnly, enabledInstances, savePaths, type Favorite } from '@/lib/storage';
 import { makeMenuId, makePathMenuId, makeCrossSeedMenuId } from '@/lib/menu-id';
 
 function isStarred(
@@ -50,78 +49,9 @@ export async function rebuildMenus(): Promise<void> {
     return;
   }
 
-  buildSendMenu(cache, selectedInstances, favs, onlyFavs, paths);
-  buildCrossSeedMenu(selectedInstances);
-}
-
-function buildCrossSeedMenu(selectedInstances: Instance[]): void {
-  // Same collapse rule as "Send to qui": one instance means the top-level
-  // item is the action itself.
-  if (selectedInstances.length === 1) {
-    browser.contextMenus.create({
-      id: makeCrossSeedMenuId(selectedInstances[0]!.id),
-      title: 'Cross-seed in qui',
-      contexts: ['link'],
-    });
-    return;
-  }
-
   browser.contextMenus.create({
-    id: 'cross-seed-in-qui',
-    title: 'Cross-seed in qui',
-    contexts: ['link'],
-  });
-  for (const instance of selectedInstances) {
-    browser.contextMenus.create({
-      id: makeCrossSeedMenuId(instance.id),
-      parentId: 'cross-seed-in-qui',
-      title: instance.name,
-      contexts: ['link'],
-    });
-  }
-}
-
-function buildSendMenu(
-  cache: CacheData,
-  selectedInstances: Instance[],
-  favs: Favorite[],
-  onlyFavs: boolean,
-  paths: string[],
-): void {
-  // Save paths are global, so they show in every mode.
-  const hasPaths = paths.length > 0;
-
-  if (onlyFavs && favs.length === 0 && !hasPaths) {
-    browser.contextMenus.create({
-      id: 'qui-no-favorites',
-      title: 'No favorites (star items in popup)',
-      contexts: ['link'],
-      enabled: false,
-    });
-    return;
-  }
-
-  if (onlyFavs && !hasPaths) {
-    const hasAnyFavorites = selectedInstances.some((instance) => {
-      const categories = cache.categoriesByInstance[instance.id] ?? [];
-      if (isStarred(favs, instance.id, '')) return true;
-      return categories.some((c) => isStarred(favs, instance.id, c.name));
-    });
-
-    if (!hasAnyFavorites) {
-      browser.contextMenus.create({
-        id: 'qui-no-selected-favorites',
-        title: 'No favorites for selected instances',
-        contexts: ['link'],
-        enabled: false,
-      });
-      return;
-    }
-  }
-
-  browser.contextMenus.create({
-    id: 'send-to-qui',
-    title: 'Send to qui',
+    id: 'qui',
+    title: 'qui',
     contexts: ['link'],
   });
 
@@ -136,17 +66,29 @@ function buildSendMenu(
     const showNoCategory = !onlyFavs || hasNoCategoryFav;
     const shownCategories = onlyFavs ? starred : [...starred, ...unstarred];
 
-    if (!showNoCategory && shownCategories.length === 0 && !hasPaths) {
-      continue;
-    }
-
     const instanceMenuId = `instance-${instance.id}`;
-    const parentId = singleInstance ? 'send-to-qui' : instanceMenuId;
+    const parentId = singleInstance ? 'qui' : instanceMenuId;
     if (!singleInstance) {
       browser.contextMenus.create({
         id: instanceMenuId,
-        parentId: 'send-to-qui',
+        parentId: 'qui',
         title: instance.name,
+        contexts: ['link'],
+      });
+    }
+
+    browser.contextMenus.create({
+      id: makeCrossSeedMenuId(instance.id),
+      parentId,
+      title: 'Cross-seed in qui',
+      contexts: ['link'],
+    });
+
+    if (showNoCategory || shownCategories.length > 0) {
+      browser.contextMenus.create({
+        id: `categories-sep-${instance.id}`,
+        parentId,
+        type: 'separator',
         contexts: ['link'],
       });
     }
@@ -169,15 +111,13 @@ function buildSendMenu(
       });
     }
 
-    if (hasPaths) {
-      if (showNoCategory || shownCategories.length > 0) {
-        browser.contextMenus.create({
-          id: `paths-sep-${instance.id}`,
-          parentId,
-          type: 'separator',
-          contexts: ['link'],
-        });
-      }
+    if (paths.length > 0) {
+      browser.contextMenus.create({
+        id: `paths-sep-${instance.id}`,
+        parentId,
+        type: 'separator',
+        contexts: ['link'],
+      });
       for (const savePath of paths) {
         browser.contextMenus.create({
           id: makePathMenuId(instance.id, savePath),

--- a/test/menus.test.ts
+++ b/test/menus.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeEach, expect, spyOn, test } from 'bun:test';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+
+const originalBrowser = Reflect.get(globalThis, 'browser');
+Object.assign(globalThis, { browser: fakeBrowser });
+const { rebuildMenus } = await import('../lib/menus');
+
+type MenuItem = Parameters<typeof fakeBrowser.contextMenus.create>[0];
+const items: MenuItem[] = [];
+const create = spyOn(fakeBrowser.contextMenus, 'create').mockImplementation((item) => {
+  items.push(item);
+  return item.id!;
+});
+const removeAll = spyOn(fakeBrowser.contextMenus, 'removeAll').mockImplementation(async () => {
+  items.length = 0;
+});
+
+beforeEach(async () => {
+  fakeBrowser.reset();
+  items.length = 0;
+  await fakeBrowser.storage.local.set({
+    cachedData: {
+      instances: [
+        { id: '1', name: 'First', host: 'https://first.test' },
+        { id: '2', name: 'Second', host: 'https://second.test' },
+      ],
+      categoriesByInstance: {
+        '1': [
+          { name: 'movies', savePath: '/movies' },
+          { name: 'tv|shows', savePath: '/tv' },
+          { name: 'music', savePath: '/music' },
+        ],
+        '2': [{ name: 'books', savePath: '/books' }],
+      },
+      lastRefreshed: 1,
+    },
+    favorites: [{ instanceId: '1', category: 'tv|shows' }],
+    savePaths: ['/z|downloads', 'D:\\Downloads'],
+  });
+});
+
+afterAll(() => {
+  create.mockRestore();
+  removeAll.mockRestore();
+  fakeBrowser.reset();
+  Object.assign(globalThis, { browser: originalBrowser });
+});
+
+function menu(parentId?: string): string[] {
+  return items.filter((item) => item.parentId === parentId).map((item) =>
+    item.type === 'separator' ? '---' : `${item.id}: ${item.title}`,
+  );
+}
+
+test('one selected instance puts all sections directly under qui', async () => {
+  await fakeBrowser.storage.local.set({ enabledInstances: ['1'] });
+  await rebuildMenus();
+
+  expect(menu()).toEqual(['qui: qui']);
+  expect(menu('qui')).toEqual([
+    'cross-seed|1|: Cross-seed in qui',
+    '---',
+    'add|1|: (No category)',
+    'add|1|tv|shows: tv|shows',
+    'add|1|movies: movies',
+    'add|1|music: music',
+    '---',
+    'path|1|/z|downloads: /z|downloads',
+    'path|1|D:\\Downloads: D:\\Downloads',
+  ]);
+  expect(items.every((item) => item.contexts?.join() === 'link')).toBe(true);
+
+  const initial = [...items];
+  await rebuildMenus();
+  expect(items).toEqual(initial);
+});
+
+test('multiple instances each retain cross-seed and paths in favorites only', async () => {
+  await fakeBrowser.storage.local.set({ favoritesOnly: true });
+  await rebuildMenus();
+
+  expect(menu()).toEqual(['qui: qui']);
+  expect(menu('qui')).toEqual(['instance-1: First', 'instance-2: Second']);
+  expect(menu('instance-1')).toEqual([
+    'cross-seed|1|: Cross-seed in qui',
+    '---',
+    'add|1|tv|shows: tv|shows',
+    '---',
+    'path|1|/z|downloads: /z|downloads',
+    'path|1|D:\\Downloads: D:\\Downloads',
+  ]);
+  expect(menu('instance-2')).toEqual([
+    'cross-seed|2|: Cross-seed in qui',
+    '---',
+    'path|2|/z|downloads: /z|downloads',
+    'path|2|D:\\Downloads: D:\\Downloads',
+  ]);
+});
+
+test.each([{ favorites: [] }, { favorites: [{ instanceId: '1', category: 'deleted' }] }])(
+  'favorites only with no visible categories keeps cross-seed without a separator: %j',
+  async ({ favorites }) => {
+    await fakeBrowser.storage.local.set({
+      enabledInstances: ['1'], favoritesOnly: true, favorites, savePaths: [],
+    });
+    await rebuildMenus();
+
+    expect(menu()).toEqual(['qui: qui']);
+    expect(menu('qui')).toEqual(['cross-seed|1|: Cross-seed in qui']);
+  },
+);
+
+test('favorites only shows no-category when starred, without a trailing separator', async () => {
+  await fakeBrowser.storage.local.set({
+    enabledInstances: ['2'],
+    favoritesOnly: true,
+    favorites: [{ instanceId: '2', category: '' }],
+    savePaths: [],
+  });
+  await rebuildMenus();
+
+  expect(menu()).toEqual(['qui: qui']);
+  expect(menu('qui')).toEqual([
+    'cross-seed|2|: Cross-seed in qui',
+    '---',
+    'add|2|: (No category)',
+  ]);
+});
+
+test('no cached instances keeps the settings message', async () => {
+  await fakeBrowser.storage.local.remove('cachedData');
+  await rebuildMenus();
+
+  expect(menu()).toEqual(['qui-no-instances: No instances (configure in settings)']);
+  expect(items[0]?.enabled).toBe(false);
+});
+
+test.each([{ enabledInstances: [] }, { enabledInstances: ['deleted'] }])('no selected instances keeps the settings message: %j', async (settings) => {
+  await fakeBrowser.storage.local.set({ enabledInstances: settings.enabledInstances });
+  await rebuildMenus();
+
+  expect(menu()).toEqual(['qui-no-selected-instances: No instances selected (configure in settings)']);
+  expect(items[0]?.enabled).toBe(false);
+});


### PR DESCRIPTION
Removes the extra "Send to qui" submenu and puts cross-seed, categories, and saved paths under each enabled instance.

Closes #31

Chrome and Firefox field tests are pending.
